### PR TITLE
Fix link handling in description

### DIFF
--- a/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.text.TextUtils;
-import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -139,10 +138,6 @@ public class PlaceDetailActivity extends AppCompatActivity {
             int current = view.getMaxLines();
             if (current == DESCRIPTION_COLLAPSED_LINE_COUNT) {
                 view.setMaxLines(DESCRIPTION_EXPANDED_MAX_LINES);
-                // Make links within card clickable, but only when expanded
-                // because LinkMovementMethod is a subclass of ScrollingMovementMethod
-                // and will make the card scroll instead of ellipsize if the text overflows.
-                descriptionView.setMovementMethod(LinkMovementMethod.getInstance());
             } else {
                 view.setMaxLines(DESCRIPTION_COLLAPSED_LINE_COUNT);
                 view.setEllipsize(TextUtils.TruncateAt.END);

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -81,6 +81,7 @@
                 android:id="@+id/place_detail_description_text"
                 android:ellipsize="end"
                 android:maxLines="4"
+                android:autoLink="all"
                 style="@style/GpgDetailText" />
 
         </android.support.v7.widget.CardView>


### PR DESCRIPTION
Replace link movement method with autoLink property to make links clickable in place description.
Fixes scrolling behavior also changing.