### PR TITLE
Feature/kak/add events list#17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/modules.xml
+.idea/caches/
 
 # Keystore files
 *.jks

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,29 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <Objective-C-extensions>
+      <file>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      </file>
+      <class>
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      </class>
+      <extensions>
+        <pair source="cpp" header="h" fileNamingConvention="NONE" />
+        <pair source="c" header="h" fileNamingConvention="NONE" />
+      </extensions>
+    </Objective-C-extensions>
+  </code_scheme>
+</component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Architecture Components
-    def archComponentsVersion = '1.1.0'
+    def archComponentsVersion = '1.1.1'
     def roomVersion = '1.0.0'
     // ViewModel and LiveData
     implementation "android.arch.lifecycle:extensions:$archComponentsVersion"
@@ -49,7 +49,7 @@ dependencies {
     // Carousel
     implementation 'com.github.flibbertigibbet:carouselview:1.0.5'
     // Badges
-    compile 'com.github.nekocode:Badge:2.0'
+    implementation 'com.github.nekocode:Badge:2.0'
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.6.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
@@ -61,13 +61,14 @@ dependencies {
     // Okio log interceptor
     implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
     // Dagger 2
-    def daggerVersion = '2.14.1'
+    def daggerVersion = '2.15'
     implementation "com.google.dagger:dagger:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation "com.google.dagger:dagger-android:$daggerVersion"
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
+    // testing
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,3 +79,4 @@ dependencies {
 
 
 
+

--- a/app/schemas/com.gophillygo.app.data.GpgDatabase/5.json
+++ b/app/schemas/com.gophillygo.app.data.GpgDatabase/5.json
@@ -1,0 +1,165 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "d30b18f0cc6c010bef1b41fb47504a75",
+    "entities": [
+      {
+        "tableName": "Destination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT, `state` TEXT, `address` TEXT, `watershed_alliance` INTEGER NOT NULL, `zipcode` TEXT, `distance` REAL NOT NULL, `formattedDistance` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `x` REAL, `y` REAL, `street_address` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watershedAlliance",
+            "columnName": "watershed_alliance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipCode",
+            "columnName": "zipcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formattedDistance",
+            "columnName": "formattedDistance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.x",
+            "columnName": "x",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.y",
+            "columnName": "y",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attributes.streetAddress",
+            "columnName": "street_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"d30b18f0cc6c010bef1b41fb47504a75\")"
+    ]
+  }
+}

--- a/app/schemas/com.gophillygo.app.data.GpgDatabase/6.json
+++ b/app/schemas/com.gophillygo.app.data.GpgDatabase/6.json
@@ -1,0 +1,399 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "03a4c26e8dc1961ab7cddcde1ca546c4",
+    "entities": [
+      {
+        "tableName": "Destination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT, `state` TEXT, `address` TEXT, `categories` TEXT, `watershed_alliance` INTEGER NOT NULL, `zipcode` TEXT, `distance` REAL NOT NULL, `formattedDistance` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `x` REAL, `y` REAL, `street_address` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watershedAlliance",
+            "columnName": "watershed_alliance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipCode",
+            "columnName": "zipcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formattedDistance",
+            "columnName": "formattedDistance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.x",
+            "columnName": "x",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.y",
+            "columnName": "y",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attributes.streetAddress",
+            "columnName": "street_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Destination_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Destination_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Destination_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Destination_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Destination_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `start_date` TEXT, `end_date` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Event_destination",
+            "unique": false,
+            "columnNames": [
+              "destination"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_destination` ON `${TABLE_NAME}` (`destination`)"
+          },
+          {
+            "name": "index_Event_start_date",
+            "unique": false,
+            "columnNames": [
+              "start_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_start_date` ON `${TABLE_NAME}` (`start_date`)"
+          },
+          {
+            "name": "index_Event_end_date",
+            "unique": false,
+            "columnNames": [
+              "end_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_end_date` ON `${TABLE_NAME}` (`end_date`)"
+          },
+          {
+            "name": "index_Event_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Event_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Event_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Event_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Event_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Destination",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "destination"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"03a4c26e8dc1961ab7cddcde1ca546c4\")"
+    ]
+  }
+}

--- a/app/schemas/com.gophillygo.app.data.GpgDatabase/7.json
+++ b/app/schemas/com.gophillygo.app.data.GpgDatabase/7.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 6,
-    "identityHash": "03a4c26e8dc1961ab7cddcde1ca546c4",
+    "version": 7,
+    "identityHash": "31d4b725a21a9f16e80079005e8d627c",
     "entities": [
       {
         "tableName": "Destination",
@@ -205,12 +205,18 @@
       },
       {
         "tableName": "Event",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `start_date` TEXT, `end_date` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `destinationName` TEXT, `start_date` TEXT, `end_date` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
         "fields": [
           {
-            "fieldPath": "destinationId",
+            "fieldPath": "destination",
             "columnName": "destination",
             "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "destinationName",
+            "columnName": "destinationName",
+            "affinity": "TEXT",
             "notNull": false
           },
           {
@@ -393,7 +399,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"03a4c26e8dc1961ab7cddcde1ca546c4\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"31d4b725a21a9f16e80079005e8d627c\")"
     ]
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "https://gophillygo.org” -->
+                <data android:scheme="https"
+                    android:host="gophillygo.org" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".PlacesListActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,13 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.gophillygo.app.PlacesListActivity" />
         </activity>
-        <activity android:name=".EventsListActivity"></activity>
+        <activity android:name=".EventsListActivity"
+            android:label="@string/events_list_title"
+            android:parentActivityName=".HomeActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.gophillygo.app.HomeActivity" />
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,12 +34,14 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.gophillygo.app.HomeActivity" />
         </activity>
-        <activity android:name=".PlaceDetailActivity"
+        <activity
+            android:name=".PlaceDetailActivity"
             android:parentActivityName=".PlacesListActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.gophillygo.app.PlacesListActivity" />
         </activity>
+        <activity android:name=".EventsListActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gophillygo/app/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/EventsListActivity.java
@@ -41,16 +41,20 @@ public class EventsListActivity extends AppCompatActivity
     EventViewModel viewModel;
 
     /**
-     * Go to place detail view when a place in the list clicked.
+     * TODO: #20
+     * Go to event detail view when an event in the list clicked.
      *
      * @param position Offset of the position of the list item clicked
      */
-    public void clickedPlace(int position) {
+    public void clickedEvent(int position) {
         // Get database ID for place clicked, based on positional offset, and pass it along
-        long destinationId = eventsListView.getAdapter().getItemId(position);
-        Intent intent = new Intent(this, PlaceDetailActivity.class);
-        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, destinationId);
+        long eventId = eventsListView.getAdapter().getItemId(position);
+        Log.d(LOG_LABEL, "Clicked event with ID: " + eventId);
+        /*
+        Intent intent = new Intent(this, EventDetailActivity.class);
+        intent.putExtra(EventDetailActivity.EVENT_ID_KEY, eventId);
         startActivity(intent);
+        */
     }
 
 

--- a/app/src/main/java/com/gophillygo/app/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/EventsListActivity.java
@@ -1,17 +1,12 @@
 package com.gophillygo.app;
 
 import android.arch.lifecycle.ViewModelProviders;
-import android.graphics.drawable.Drawable;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.Button;
 
 import com.gophillygo.app.adapters.EventsListAdapter;
 import com.gophillygo.app.data.EventViewModel;
@@ -20,24 +15,23 @@ import com.gophillygo.app.di.GpgViewModelFactory;
 
 import javax.inject.Inject;
 
-import cn.nekocode.badge.BadgeDrawable;
-
-public class EventsListActivity extends AppCompatActivity
-        implements FilterDialog.FilterChangeListener, EventsListAdapter.EventListItemClickListener {
+public class EventsListActivity extends FilterableListActivity
+        implements EventsListAdapter.EventListItemClickListener {
 
     private static final String LOG_LABEL = "EventsList";
 
     private LinearLayoutManager layoutManager;
     private RecyclerView eventsListView;
-    private Toolbar toolbar;
-    private Button filterButton;
-    private Drawable filterIcon;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
     GpgViewModelFactory viewModelFactory;
     @SuppressWarnings("WeakerAccess")
     EventViewModel viewModel;
+
+    public EventsListActivity() {
+        super(R.layout.activity_events_list, R.id.events_list_toolbar, R.id.events_list_filter_button);
+    }
 
     /**
      * TODO: #20
@@ -46,7 +40,7 @@ public class EventsListActivity extends AppCompatActivity
      * @param position Offset of the position of the list item clicked
      */
     public void clickedEvent(int position) {
-        // Get database ID for place clicked, based on positional offset, and pass it along
+        // Get database ID for event clicked, based on positional offset, and pass it along
         long eventId = eventsListView.getAdapter().getItemId(position);
         Log.d(LOG_LABEL, "Clicked event with ID: " + eventId);
         /*
@@ -60,17 +54,7 @@ public class EventsListActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_events_list);
 
-        filterIcon = ContextCompat.getDrawable(this, R.drawable.ic_filter_list_white_24px);
-
-        // set up toolbar
-        toolbar = findViewById(R.id.events_list_toolbar);
-        setSupportActionBar(toolbar);
-        //noinspection ConstantConditions
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
-        // set up list of places
         layoutManager = new LinearLayoutManager(this);
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(EventViewModel.class);
@@ -85,12 +69,6 @@ public class EventsListActivity extends AppCompatActivity
             }
         });
 
-        // set up filter button
-        filterButton = findViewById(R.id.events_list_filter_button);
-        filterButton.setOnClickListener(v -> {
-            FilterDialog filterDialog = new FilterDialog();
-            filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
-        });
     }
 
     @Override
@@ -117,23 +95,5 @@ public class EventsListActivity extends AppCompatActivity
                 return super.onOptionsItemSelected(item);
         }
         return true;
-    }
-
-    @Override
-    public void filtersChanged(int setFilterCount) {
-        // Change filter button's left drawable when filters set to either be a badge with the
-        // filter count, or the default filter icon, if no filters set.
-        if (setFilterCount > 0) {
-            Drawable filterDrawable = new BadgeDrawable.Builder()
-                    .type(BadgeDrawable.TYPE_ONLY_ONE_TEXT)
-                    .badgeColor(ContextCompat.getColor(this, R.color.color_white))
-                    .textColor(ContextCompat.getColor(this, R.color.color_primary))
-                    .text1(String.valueOf(setFilterCount))
-                    .build();
-            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterDrawable, null, null, null);
-        } else {
-            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
-        }
-
     }
 }

--- a/app/src/main/java/com/gophillygo/app/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/EventsListActivity.java
@@ -1,7 +1,6 @@
 package com.gophillygo.app;
 
 import android.arch.lifecycle.ViewModelProviders;
-import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;

--- a/app/src/main/java/com/gophillygo/app/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/EventsListActivity.java
@@ -1,0 +1,136 @@
+package com.gophillygo.app;
+
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.Button;
+
+import com.gophillygo.app.adapters.EventsListAdapter;
+import com.gophillygo.app.data.EventViewModel;
+import com.gophillygo.app.data.networkresource.Status;
+import com.gophillygo.app.di.GpgViewModelFactory;
+
+import javax.inject.Inject;
+
+import cn.nekocode.badge.BadgeDrawable;
+
+public class EventsListActivity extends AppCompatActivity
+        implements FilterDialog.FilterChangeListener, EventsListAdapter.EventListItemClickListener {
+
+    private static final String LOG_LABEL = "EventsList";
+
+    private LinearLayoutManager layoutManager;
+    private RecyclerView eventsListView;
+    private Toolbar toolbar;
+    private Button filterButton;
+    private Drawable filterIcon;
+
+    @SuppressWarnings("WeakerAccess")
+    @Inject
+    GpgViewModelFactory viewModelFactory;
+    @SuppressWarnings("WeakerAccess")
+    EventViewModel viewModel;
+
+    /**
+     * Go to place detail view when a place in the list clicked.
+     *
+     * @param position Offset of the position of the list item clicked
+     */
+    public void clickedPlace(int position) {
+        // Get database ID for place clicked, based on positional offset, and pass it along
+        long destinationId = eventsListView.getAdapter().getItemId(position);
+        Intent intent = new Intent(this, PlaceDetailActivity.class);
+        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, destinationId);
+        startActivity(intent);
+    }
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_events_list);
+
+        filterIcon = ContextCompat.getDrawable(this, R.drawable.ic_filter_list_white_24px);
+
+        // set up toolbar
+        toolbar = findViewById(R.id.events_list_toolbar);
+        setSupportActionBar(toolbar);
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        // set up list of places
+        layoutManager = new LinearLayoutManager(this);
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(EventViewModel.class);
+        viewModel.getEvents().observe(this, destinationResource -> {
+            if (destinationResource != null && destinationResource.status.equals(Status.SUCCESS) &&
+                    destinationResource.data != null && !destinationResource.data.isEmpty()) {
+
+                eventsListView = findViewById(R.id.events_list_recycler_view);
+                EventsListAdapter adapter = new EventsListAdapter(this, destinationResource.data, this);
+                eventsListView.setAdapter(adapter);
+                eventsListView.setLayoutManager(layoutManager);
+            }
+        });
+
+        // set up filter button
+        filterButton = findViewById(R.id.events_list_filter_button);
+        filterButton.setOnClickListener(v -> {
+            FilterDialog filterDialog = new FilterDialog();
+            filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
+        });
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.events_list_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        int itemId = item.getItemId();
+        switch (itemId) {
+            case R.id.action_event_place:
+                Log.d(LOG_LABEL, "Selected event place menu item");
+                break;
+            case R.id.action_event_map:
+                Log.d(LOG_LABEL, "Selected map menu item");
+                break;
+            case R.id.action_event_search:
+                Log.d(LOG_LABEL, "Selected search menu item");
+                break;
+            default:
+                Log.w(LOG_LABEL, "Unrecognized menu item selected: " + String.valueOf(itemId));
+                return super.onOptionsItemSelected(item);
+        }
+        return true;
+    }
+
+    @Override
+    public void filtersChanged(int setFilterCount) {
+        // Change filter button's left drawable when filters set to either be a badge with the
+        // filter count, or the default filter icon, if no filters set.
+        if (setFilterCount > 0) {
+            Drawable filterDrawable = new BadgeDrawable.Builder()
+                    .type(BadgeDrawable.TYPE_ONLY_ONE_TEXT)
+                    .badgeColor(ContextCompat.getColor(this, R.color.color_white))
+                    .textColor(ContextCompat.getColor(this, R.color.color_primary))
+                    .text1(String.valueOf(setFilterCount))
+                    .build();
+            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterDrawable, null, null, null);
+        } else {
+            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
+        }
+
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/FilterDialog.java
+++ b/app/src/main/java/com/gophillygo/app/FilterDialog.java
@@ -41,7 +41,9 @@ public class FilterDialog extends BottomSheetDialogFragment {
 
         Log.d(LOG_LABEL, "Selected " + String.valueOf(selectedFilterCount) + " filters.");
         FilterChangeListener listener = (FilterChangeListener) getActivity();
-        listener.filtersChanged(selectedFilterCount);
+        if (listener != null) {
+            listener.filtersChanged(selectedFilterCount);
+        }
 
         super.onDismiss(dialog);
     }
@@ -77,9 +79,7 @@ public class FilterDialog extends BottomSheetDialogFragment {
         doneButton = dialog.findViewById(R.id.filter_modal_done_button);
         resetButton = dialog.findViewById(R.id.filter_modal_reset_button);
 
-        doneButton.setOnClickListener(v -> {
-            dismiss();
-        });
+        doneButton.setOnClickListener(v -> dismiss());
 
         resetButton.setOnClickListener(v -> {
             for (GpgToggleButton button: filterButtons) {

--- a/app/src/main/java/com/gophillygo/app/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/FilterableListActivity.java
@@ -1,0 +1,70 @@
+package com.gophillygo.app;
+
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.widget.Button;
+
+import cn.nekocode.badge.BadgeDrawable;
+
+/**
+ * Abstract list activity with a filter popover opened by a filter toolbar button.
+ * Toolbar button updates to display count of filters currently applied.
+ */
+
+public abstract class FilterableListActivity extends AppCompatActivity
+        implements FilterDialog.FilterChangeListener {
+
+    private int layoutId, toolbarId, filterButtonId;
+
+    private Button filterButton;
+    private Drawable filterIcon;
+    private Toolbar toolbar;
+
+    public FilterableListActivity(int layoutId, int toolbarId, int filterButtonId) {
+        this.layoutId = layoutId;
+        this.toolbarId = toolbarId;
+        this.filterButtonId = filterButtonId;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(layoutId);
+
+        // set up toolbar
+        toolbar = findViewById(toolbarId);
+        setSupportActionBar(toolbar);
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        filterIcon = ContextCompat.getDrawable(this, R.drawable.ic_filter_list_white_24px);
+
+        // set up filter button
+        filterButton = findViewById(filterButtonId);
+        filterButton.setOnClickListener(v -> {
+            FilterDialog filterDialog = new FilterDialog();
+            filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
+        });
+    }
+
+    @Override
+    public void filtersChanged(int setFilterCount) {
+        // Change filter button's left drawable when filters set to either be a badge with the
+        // filter count, or the default filter icon, if no filters set.
+        if (setFilterCount > 0) {
+            Drawable filterDrawable = new BadgeDrawable.Builder()
+                    .type(BadgeDrawable.TYPE_ONLY_ONE_TEXT)
+                    .badgeColor(ContextCompat.getColor(this, R.color.color_white))
+                    .textColor(ContextCompat.getColor(this, R.color.color_primary))
+                    .text1(String.valueOf(setFilterCount))
+                    .build();
+            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterDrawable, null, null, null);
+        } else {
+            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
+        }
+
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/HomeActivity.java
@@ -86,9 +86,8 @@ public class HomeActivity extends AppCompatActivity {
                 return;
             }
 
+            // if querying from server, state may update with LOADING status before it finishes
             if (!destinationResource.status.equals(Status.SUCCESS)) {
-                Log.e(LOG_LABEL, "Destination query failed with status: " +
-                        destinationResource.status.name());
                 return;
             }
 

--- a/app/src/main/java/com/gophillygo/app/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/HomeActivity.java
@@ -212,7 +212,15 @@ public class HomeActivity extends AppCompatActivity {
     private void clickedGridItem(int position) {
         Log.d(LOG_LABEL, "clicked grid view item: " + position);
 
-        Intent intent = new Intent(this, PlacesListActivity.class);
-        startActivity(intent);
+        switch (position) {
+            case 0:
+                // go to events list
+                startActivity(new Intent(this, EventsListActivity.class));
+                break;
+            default:
+                // go to places list
+                // TODO: #18 filter list based on selected grid item
+                startActivity(new Intent(this, PlacesListActivity.class));
+        }
     }
 }

--- a/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
@@ -110,7 +110,7 @@ public class PlaceDetailActivity extends AppCompatActivity {
         };
     }
 
-    @SuppressLint("RestrictedApi")
+    @SuppressLint({"RestrictedApi", "RtlHardcoded"})
     private void displayDestination() {
         // set up carousel
         carouselView.setViewListener(viewListener);
@@ -151,9 +151,8 @@ public class PlaceDetailActivity extends AppCompatActivity {
         upcomingEventsView.setText(upcomingEventsText);
         upcomingEventsView.setVisibility(View.VISIBLE);
         // TODO: #18 go to filtered event list with events for destination on click
-        upcomingEventsView.setOnClickListener(v -> {
-            Log.d(LOG_LABEL, "Clicked upcoming events for destination " +  destination.getName());
-        });
+        upcomingEventsView.setOnClickListener(v -> Log.d(LOG_LABEL,
+                "Clicked upcoming events for destination " +  destination.getName()));
 
         // expand/collapse description card when clicked
         descriptionView = findViewById(R.id.place_detail_description_text);

--- a/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/PlaceDetailActivity.java
@@ -213,6 +213,9 @@ public class PlaceDetailActivity extends AppCompatActivity {
         getDirectionsButton.setOnClickListener(v -> {
             // pass parameters destination and destinationText to https://gophillygo.org/
             Uri directionsUri = new Uri.Builder().scheme("https").authority("gophillygo.org")
+                    // TODO: #9 send current user location as origin
+                    .appendQueryParameter("origin", "")
+                    .appendQueryParameter("originText", "")
                     .appendQueryParameter("destination", destination.getLocation().toString())
                     .appendQueryParameter("destinationText", destination.getAddress()).build();
             Intent intent = new Intent(Intent.ACTION_VIEW, directionsUri);

--- a/app/src/main/java/com/gophillygo/app/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/PlacesListActivity.java
@@ -2,17 +2,12 @@ package com.gophillygo.app;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.Button;
 
 import com.gophillygo.app.adapters.PlacesListAdapter;
 import com.gophillygo.app.data.DestinationViewModel;
@@ -21,24 +16,24 @@ import com.gophillygo.app.di.GpgViewModelFactory;
 
 import javax.inject.Inject;
 
-import cn.nekocode.badge.BadgeDrawable;
 
-public class PlacesListActivity extends AppCompatActivity implements FilterDialog.FilterChangeListener,
+public class PlacesListActivity extends FilterableListActivity implements
         PlacesListAdapter.PlaceListItemClickListener {
 
     private static final String LOG_LABEL = "PlacesList";
 
     private LinearLayoutManager layoutManager;
     private RecyclerView placesListView;
-    private Toolbar toolbar;
-    private Button filterButton;
-    private Drawable filterIcon;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
     GpgViewModelFactory viewModelFactory;
     @SuppressWarnings("WeakerAccess")
     DestinationViewModel viewModel;
+
+    public PlacesListActivity() {
+        super(R.layout.activity_places_list, R.id.places_list_toolbar, R.id.places_list_filter_button);
+    }
 
     /**
      * Go to place detail view when a place in the list clicked.
@@ -57,15 +52,6 @@ public class PlacesListActivity extends AppCompatActivity implements FilterDialo
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_places_list);
-
-        filterIcon = ContextCompat.getDrawable(this, R.drawable.ic_filter_list_white_24px);
-
-        // set up toolbar
-        toolbar = findViewById(R.id.places_list_toolbar);
-        setSupportActionBar(toolbar);
-        //noinspection ConstantConditions
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         // set up list of places
         layoutManager = new LinearLayoutManager(this);
@@ -82,12 +68,6 @@ public class PlacesListActivity extends AppCompatActivity implements FilterDialo
             }
         });
 
-        // set up filter button
-        filterButton = findViewById(R.id.places_list_filter_button);
-        filterButton.setOnClickListener(v -> {
-            FilterDialog filterDialog = new FilterDialog();
-            filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
-        });
     }
 
     @Override
@@ -114,23 +94,5 @@ public class PlacesListActivity extends AppCompatActivity implements FilterDialo
                 return super.onOptionsItemSelected(item);
         }
         return true;
-    }
-
-    @Override
-    public void filtersChanged(int setFilterCount) {
-        // Change filter button's left drawable when filters set to either be a badge with the
-        // filter count, or the default filter icon, if no filters set.
-        if (setFilterCount > 0) {
-            Drawable filterDrawable = new BadgeDrawable.Builder()
-                    .type(BadgeDrawable.TYPE_ONLY_ONE_TEXT)
-                    .badgeColor(ContextCompat.getColor(this, R.color.color_white))
-                    .textColor(ContextCompat.getColor(this, R.color.color_primary))
-                    .text1(String.valueOf(setFilterCount))
-                    .build();
-            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterDrawable, null, null, null);
-        } else {
-            filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
-        }
-
     }
 }

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -20,7 +20,7 @@ import com.gophillygo.app.data.models.Event;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -56,6 +56,7 @@ public class EventsListAdapter extends RecyclerView.Adapter {
         TextView monthView;
         TextView dayOfMonthView;
         TextView dayOfWeekView;
+        TextView timesView;
 
         private ViewHolder(View parentView, final EventListItemClickListener listener) {
             super(parentView);
@@ -118,6 +119,22 @@ public class EventsListAdapter extends RecyclerView.Adapter {
             viewHolder.monthView.setText(monthFormat.format(startDate));
             viewHolder.dayOfMonthView.setText(dayOfMonthFormat.format(startDate));
             viewHolder.dayOfWeekView.setText(dayOfWeekFormat.format(startDate));
+
+            // check if event ends on same day as it starts
+            Calendar startCalendar = Calendar.getInstance();
+            Calendar endCalendar = Calendar.getInstance();
+            startCalendar.setTime(startDate);
+            endCalendar.setTime(endDate);
+
+            // TODO: set times or date range with times
+            if (startCalendar.get(Calendar.YEAR) == endCalendar.get(Calendar.YEAR) &&
+                    startCalendar.get(Calendar.DAY_OF_YEAR) == endCalendar.get(Calendar.DAY_OF_YEAR)) {
+
+
+            } else {
+                // multi-day event
+
+            }
         } catch (ParseException e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -64,9 +64,7 @@ public class EventsListAdapter extends RecyclerView.Adapter {
         private ViewHolder(View parentView, final EventListItemClickListener listener) {
             super(parentView);
 
-            parentView.setOnClickListener(v -> {
-                listener.clickedEvent(getAdapterPosition());
-            });
+            parentView.setOnClickListener(v -> listener.clickedEvent(getAdapterPosition()));
         }
     }
 

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -1,0 +1,139 @@
+package com.gophillygo.app.adapters;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.v7.view.menu.MenuBuilder;
+import android.support.v7.view.menu.MenuPopupHelper;
+import android.support.v7.widget.PopupMenu;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.gophillygo.app.R;
+import com.gophillygo.app.data.models.Event;
+
+import java.util.List;
+
+public class EventsListAdapter extends RecyclerView.Adapter {
+
+    public interface EventListItemClickListener {
+        void clickedPlace(int position);
+    }
+
+    private static final String LOG_LABEL = "EventListAdapter";
+
+    private final Context context;
+    private final LayoutInflater inflater;
+    private EventListItemClickListener clickListener;
+
+    private List<Event> eventList;
+
+    private static class ViewHolder extends RecyclerView.ViewHolder {
+        ImageView imageView;
+        TextView eventNameView;
+        TextView distanceView;
+        ImageButton eventOptionsButton;
+        ImageView cyclingMarker;
+        ImageView watershedAllianceMarker;
+
+        private ViewHolder(View parentView, final EventListItemClickListener listener) {
+            super(parentView);
+
+            parentView.setOnClickListener(v -> {
+                listener.clickedPlace(getAdapterPosition());
+            });
+        }
+    }
+
+    public EventsListAdapter(Context context, List<Event> events, EventListItemClickListener listener) {
+        this.context = context;
+        this.inflater = LayoutInflater.from(context);
+        this.eventList = events;
+        this.clickListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View parentView = inflater.inflate(R.layout.place_list_item, parent, false);
+        ViewHolder viewHolder = new ViewHolder(parentView, this.clickListener);
+
+        viewHolder.imageView = parentView.findViewById(R.id.place_list_item_image);
+        viewHolder.eventNameView = parentView.findViewById(R.id.place_list_item_name_label);
+        viewHolder.distanceView = parentView.findViewById(R.id.place_list_item_distance_label);
+        viewHolder.eventOptionsButton = parentView.findViewById(R.id.place_list_item_options_button);
+        viewHolder.watershedAllianceMarker = parentView.findViewById(R.id.place_list_watershed_alliance_marker);
+        viewHolder.cyclingMarker = parentView.findViewById(R.id.place_list_cycling_activity_marker);
+
+        parentView.setTag(viewHolder);
+
+        return viewHolder;
+    }
+
+    @SuppressLint("RestrictedApi")
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        Event event = eventList.get(position);
+        ViewHolder viewHolder = (ViewHolder) holder;
+
+        viewHolder.eventNameView.setText(event.getName());
+
+        /*
+        Destination destination = event.getDestination();
+
+        if (destination.isWatershedAlliance()) {
+            viewHolder.watershedAllianceMarker.setVisibility(View.VISIBLE);
+            viewHolder.watershedAllianceMarker.invalidate();
+        } else {
+            viewHolder.watershedAllianceMarker.setVisibility(View.GONE);
+        }
+
+        if (destination.isCycling()) {
+            viewHolder.cyclingMarker.setVisibility(View.VISIBLE);
+        } else {
+            viewHolder.cyclingMarker.setVisibility(View.GONE);
+        }
+        */
+
+        viewHolder.eventOptionsButton.setOnClickListener(v -> {
+            Log.d(LOG_LABEL, "Clicked event options button for event #" + event.getId());
+            PopupMenu menu = new PopupMenu(context, viewHolder.eventOptionsButton);
+            menu.getMenuInflater().inflate(R.menu.place_options_menu, menu.getMenu());
+            menu.setOnMenuItemClickListener(item -> {
+                Log.d(LOG_LABEL, "Clicked " + item.toString());
+                return true;
+            });
+
+            // Force icons to show in the popup menu via the support library API
+            // https://stackoverflow.com/questions/6805756/is-it-possible-to-display-icons-in-a-popupmenu
+            MenuPopupHelper popupHelper = new MenuPopupHelper(context,
+                    (MenuBuilder)menu.getMenu(),
+                    viewHolder.eventOptionsButton);
+            popupHelper.setForceShowIcon(true);
+            popupHelper.show();
+        });
+    }
+
+    @Override
+    public long getItemId(int position) {
+        Event event = eventList.get(position);
+        if (event != null) {
+            return event.getId();
+        } else {
+            Log.w(LOG_LABEL, "Could not find event at offset " + String.valueOf(position));
+            return -1;
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return eventList.size();
+    }
+}
+

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -33,13 +33,16 @@ public class EventsListAdapter extends RecyclerView.Adapter {
 
     private static final String LOG_LABEL = "EventListAdapter";
 
-    private static final DateFormat isoDateFormat, monthFormat, dayOfMonthFormat, dayOfWeekFormat;
+    private static final DateFormat isoDateFormat, monthFormat, dayOfMonthFormat, dayOfWeekFormat,
+            timeFormat, monthDayFormat;
 
     static {
         isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
         monthFormat = new SimpleDateFormat("MMM", Locale.US);
         dayOfMonthFormat = new SimpleDateFormat("dd", Locale.US);
         dayOfWeekFormat = new SimpleDateFormat("EEE", Locale.US);
+        timeFormat = new SimpleDateFormat("h:mm a", Locale.US);
+        monthDayFormat = new SimpleDateFormat("MMM dd", Locale.US);
     }
 
     private final Context context;
@@ -87,6 +90,7 @@ public class EventsListAdapter extends RecyclerView.Adapter {
         viewHolder.monthView = parentView.findViewById(R.id.event_month_label);
         viewHolder.dayOfMonthView = parentView.findViewById(R.id.event_day_of_month_label);
         viewHolder.dayOfWeekView = parentView.findViewById(R.id.event_day_of_week_label);
+        viewHolder.timesView = parentView.findViewById(R.id.event_list_item_time);
 
         parentView.setTag(viewHolder);
         return viewHolder;
@@ -126,17 +130,24 @@ public class EventsListAdapter extends RecyclerView.Adapter {
             startCalendar.setTime(startDate);
             endCalendar.setTime(endDate);
 
-            // TODO: set times or date range with times
+            // set times if event is a single day event, or date range if multi-day
             if (startCalendar.get(Calendar.YEAR) == endCalendar.get(Calendar.YEAR) &&
                     startCalendar.get(Calendar.DAY_OF_YEAR) == endCalendar.get(Calendar.DAY_OF_YEAR)) {
 
-
+                viewHolder.timesView.setText(context.getString(R.string.event_list_item_time_range,
+                        timeFormat.format(startDate),
+                        timeFormat.format(endDate)));
             } else {
                 // multi-day event
-
+                viewHolder.timesView.setText(context.getString(R.string.event_list_item_time_range,
+                        monthDayFormat.format(startDate),
+                        monthDayFormat.format(endDate)));
             }
+            viewHolder.timesView.setVisibility(View.VISIBLE);
         } catch (ParseException e) {
             e.printStackTrace();
+            Log.e(LOG_LABEL, "Failed to parse an event date");
+            viewHolder.timesView.setVisibility(View.INVISIBLE);
         }
 
         viewHolder.eventOptionsButton.setOnClickListener(v -> {

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -15,10 +15,15 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 
 import com.gophillygo.app.R;
-import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.Event;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 public class EventsListAdapter extends RecyclerView.Adapter {
 
@@ -28,6 +33,15 @@ public class EventsListAdapter extends RecyclerView.Adapter {
 
     private static final String LOG_LABEL = "EventListAdapter";
 
+    private static final DateFormat isoDateFormat, monthFormat, dayOfMonthFormat, dayOfWeekFormat;
+
+    static {
+        isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+        monthFormat = new SimpleDateFormat("MMM", Locale.US);
+        dayOfMonthFormat = new SimpleDateFormat("dd", Locale.US);
+        dayOfWeekFormat = new SimpleDateFormat("EEE", Locale.US);
+    }
+
     private final Context context;
     private final LayoutInflater inflater;
     private EventListItemClickListener clickListener;
@@ -36,9 +50,12 @@ public class EventsListAdapter extends RecyclerView.Adapter {
 
     private static class ViewHolder extends RecyclerView.ViewHolder {
         TextView eventNameView;
-
         TextView destinationNameView;
         ImageButton eventOptionsButton;
+
+        TextView monthView;
+        TextView dayOfMonthView;
+        TextView dayOfWeekView;
 
         private ViewHolder(View parentView, final EventListItemClickListener listener) {
             super(parentView);
@@ -66,8 +83,11 @@ public class EventsListAdapter extends RecyclerView.Adapter {
         viewHolder.destinationNameView = parentView.findViewById(R.id.event_list_destination_name);
         viewHolder.eventOptionsButton = parentView.findViewById(R.id.event_list_item_options_button);
 
-        parentView.setTag(viewHolder);
+        viewHolder.monthView = parentView.findViewById(R.id.event_month_label);
+        viewHolder.dayOfMonthView = parentView.findViewById(R.id.event_day_of_month_label);
+        viewHolder.dayOfWeekView = parentView.findViewById(R.id.event_day_of_week_label);
 
+        parentView.setTag(viewHolder);
         return viewHolder;
     }
 
@@ -85,6 +105,21 @@ public class EventsListAdapter extends RecyclerView.Adapter {
             viewHolder.destinationNameView.setVisibility(View.VISIBLE);
         } else {
             viewHolder.destinationNameView.setVisibility(View.INVISIBLE);
+        }
+
+        String start = event.getStartDate();
+        String end = event.getEndDate();
+        Date startDate, endDate;
+
+        try {
+            startDate = isoDateFormat.parse(start);
+            endDate = isoDateFormat.parse(end);
+
+            viewHolder.monthView.setText(monthFormat.format(startDate));
+            viewHolder.dayOfMonthView.setText(dayOfMonthFormat.format(startDate));
+            viewHolder.dayOfWeekView.setText(dayOfWeekFormat.format(startDate));
+        } catch (ParseException e) {
+            e.printStackTrace();
         }
 
         viewHolder.eventOptionsButton.setOnClickListener(v -> {

--- a/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/EventsListAdapter.java
@@ -12,10 +12,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.gophillygo.app.R;
+import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.Event;
 
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
 public class EventsListAdapter extends RecyclerView.Adapter {
 
     public interface EventListItemClickListener {
-        void clickedPlace(int position);
+        void clickedEvent(int position);
     }
 
     private static final String LOG_LABEL = "EventListAdapter";
@@ -35,18 +35,16 @@ public class EventsListAdapter extends RecyclerView.Adapter {
     private List<Event> eventList;
 
     private static class ViewHolder extends RecyclerView.ViewHolder {
-        ImageView imageView;
         TextView eventNameView;
-        TextView distanceView;
+
+        TextView destinationNameView;
         ImageButton eventOptionsButton;
-        ImageView cyclingMarker;
-        ImageView watershedAllianceMarker;
 
         private ViewHolder(View parentView, final EventListItemClickListener listener) {
             super(parentView);
 
             parentView.setOnClickListener(v -> {
-                listener.clickedPlace(getAdapterPosition());
+                listener.clickedEvent(getAdapterPosition());
             });
         }
     }
@@ -61,15 +59,12 @@ public class EventsListAdapter extends RecyclerView.Adapter {
     @NonNull
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View parentView = inflater.inflate(R.layout.place_list_item, parent, false);
+        View parentView = inflater.inflate(R.layout.event_list_item, parent, false);
         ViewHolder viewHolder = new ViewHolder(parentView, this.clickListener);
-
-        viewHolder.imageView = parentView.findViewById(R.id.place_list_item_image);
-        viewHolder.eventNameView = parentView.findViewById(R.id.place_list_item_name_label);
-        viewHolder.distanceView = parentView.findViewById(R.id.place_list_item_distance_label);
-        viewHolder.eventOptionsButton = parentView.findViewById(R.id.place_list_item_options_button);
-        viewHolder.watershedAllianceMarker = parentView.findViewById(R.id.place_list_watershed_alliance_marker);
-        viewHolder.cyclingMarker = parentView.findViewById(R.id.place_list_cycling_activity_marker);
+        
+        viewHolder.eventNameView = parentView.findViewById(R.id.event_list_item_name_label);
+        viewHolder.destinationNameView = parentView.findViewById(R.id.event_list_destination_name);
+        viewHolder.eventOptionsButton = parentView.findViewById(R.id.event_list_item_options_button);
 
         parentView.setTag(viewHolder);
 
@@ -84,22 +79,13 @@ public class EventsListAdapter extends RecyclerView.Adapter {
 
         viewHolder.eventNameView.setText(event.getName());
 
-        /*
-        Destination destination = event.getDestination();
-
-        if (destination.isWatershedAlliance()) {
-            viewHolder.watershedAllianceMarker.setVisibility(View.VISIBLE);
-            viewHolder.watershedAllianceMarker.invalidate();
+        String destinationName = event.getDestinationName();
+        if (destinationName != null && !destinationName.isEmpty()) {
+            viewHolder.destinationNameView.setText(destinationName);
+            viewHolder.destinationNameView.setVisibility(View.VISIBLE);
         } else {
-            viewHolder.watershedAllianceMarker.setVisibility(View.GONE);
+            viewHolder.destinationNameView.setVisibility(View.INVISIBLE);
         }
-
-        if (destination.isCycling()) {
-            viewHolder.cyclingMarker.setVisibility(View.VISIBLE);
-        } else {
-            viewHolder.cyclingMarker.setVisibility(View.GONE);
-        }
-        */
 
         viewHolder.eventOptionsButton.setOnClickListener(v -> {
             Log.d(LOG_LABEL, "Clicked event options button for event #" + event.getId());

--- a/app/src/main/java/com/gophillygo/app/adapters/PlacesListAdapter.java
+++ b/app/src/main/java/com/gophillygo/app/adapters/PlacesListAdapter.java
@@ -32,7 +32,7 @@ public class PlacesListAdapter extends RecyclerView.Adapter {
 
     private final Context context;
     private final LayoutInflater inflater;
-    private PlaceListItemClickListener clickListener;
+    private final PlaceListItemClickListener clickListener;
 
     private List<Destination> destinationList;
 
@@ -47,9 +47,7 @@ public class PlacesListAdapter extends RecyclerView.Adapter {
         private ViewHolder(View parentView, final PlaceListItemClickListener listener) {
             super(parentView);
 
-            parentView.setOnClickListener(v -> {
-                listener.clickedPlace(getAdapterPosition());
-            });
+            parentView.setOnClickListener(v -> listener.clickedPlace(getAdapterPosition()));
         }
     }
 

--- a/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
@@ -1,13 +1,10 @@
 package com.gophillygo.app.data;
 
-import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Delete;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Transaction;
 import android.arch.persistence.room.Update;
-
-import com.gophillygo.app.data.models.Attraction;
 
 import java.util.List;
 
@@ -19,15 +16,16 @@ import java.util.List;
 interface AttractionDao<T> {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract void save(T obj);
+    void save(T obj);
 
     @Update()
-    abstract void update(T obj);
+    void update(T obj);
 
     @Delete()
-    abstract  void delete(T obj);
+    void delete(T obj);
 
-    abstract void clear();
+    @SuppressWarnings({"EmptyMethod", "unused"})
+    void clear();
 
     @Transaction
     void bulkUpdate(List<T> objs);

--- a/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
@@ -1,0 +1,34 @@
+package com.gophillygo.app.data;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.persistence.room.Delete;
+import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
+import android.arch.persistence.room.Transaction;
+import android.arch.persistence.room.Update;
+
+import java.util.List;
+
+
+/**
+ * Database access methods shared by destinations and events.
+ */
+
+interface AttractionDao<T> {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract void save(T obj);
+
+    @Update()
+    abstract void update(T obj);
+
+    @Delete()
+    abstract  void delete(T obj);
+
+    abstract void clear();
+
+    abstract LiveData<List<T>> getAll();
+
+    @Transaction
+    void bulkUpdate(List<T> objs);
+}

--- a/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/AttractionDao.java
@@ -7,6 +7,8 @@ import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Transaction;
 import android.arch.persistence.room.Update;
 
+import com.gophillygo.app.data.models.Attraction;
+
 import java.util.List;
 
 
@@ -26,8 +28,6 @@ interface AttractionDao<T> {
     abstract  void delete(T obj);
 
     abstract void clear();
-
-    abstract LiveData<List<T>> getAll();
 
     @Transaction
     void bulkUpdate(List<T> objs);

--- a/app/src/main/java/com/gophillygo/app/data/DestinationDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/DestinationDao.java
@@ -2,11 +2,8 @@ package com.gophillygo.app.data;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 import android.arch.persistence.room.Transaction;
-import android.arch.persistence.room.Update;
 
 import com.gophillygo.app.data.models.Destination;
 
@@ -17,24 +14,19 @@ import java.util.List;
  */
 
 @Dao
-public abstract class DestinationDao {
+public abstract class DestinationDao implements AttractionDao<Destination> {
     @Query("SELECT * FROM destination ORDER BY distance ASC")
-    abstract LiveData<List<Destination>> getAll();
+    public abstract LiveData<List<Destination>> getAll();
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract void save(Destination destination);
 
     @Query("SELECT * FROM destination WHERE id = :destinationId")
     abstract LiveData<Destination> getDestination(long destinationId);
 
     @Query("DELETE FROM destination")
-    abstract void clear();
-
-    @Update()
-    abstract void update(Destination destination);
+    public abstract void clear();
 
     @Transaction
-    void bulkUpdate(List<Destination> destinations) {
+    public void bulkUpdate(List<Destination> destinations) {
         for (Destination destination: destinations) {
             update(destination);
         }

--- a/app/src/main/java/com/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventDao.java
@@ -17,7 +17,8 @@ import java.util.List;
 @Dao
 public abstract class EventDao implements AttractionDao<Event> {
     @Query("SELECT event.*, destination.name AS destinationName FROM event " +
-            "LEFT JOIN destination on destination.id = event.destination")
+            "LEFT JOIN destination on destination.id = event.destination " +
+            "ORDER BY event.start_date ASC;")
     public abstract LiveData<List<Event>> getAll();
 
     @Query("SELECT * FROM event WHERE id = :eventId")

--- a/app/src/main/java/com/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventDao.java
@@ -1,0 +1,43 @@
+package com.gophillygo.app.data;
+
+
+import android.arch.lifecycle.LiveData;
+import android.arch.persistence.room.Dao;
+import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
+import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Transaction;
+import android.arch.persistence.room.Update;
+
+import com.gophillygo.app.data.models.Event;
+
+import java.util.List;
+
+/**
+ * Database access methods for events.
+ */
+
+@Dao
+public abstract class EventDao {
+    @Query("SELECT * FROM event")
+    abstract LiveData<List<Event>> getAll();
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract void save(Event event);
+
+    @Query("SELECT * FROM event WHERE id = :eventId")
+    abstract LiveData<Event> getEvent(long eventId);
+
+    @Query("DELETE FROM event")
+    abstract void clear();
+
+    @Update()
+    abstract void update(Event event);
+
+    @Transaction
+    void bulkUpdate(List<Event> events) {
+        for (Event event: events) {
+            update(event);
+        }
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventDao.java
@@ -3,11 +3,8 @@ package com.gophillygo.app.data;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 import android.arch.persistence.room.Transaction;
-import android.arch.persistence.room.Update;
 
 import com.gophillygo.app.data.models.Event;
 
@@ -18,24 +15,18 @@ import java.util.List;
  */
 
 @Dao
-public abstract class EventDao {
+public abstract class EventDao implements AttractionDao<Event> {
     @Query("SELECT * FROM event")
-    abstract LiveData<List<Event>> getAll();
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract void save(Event event);
+    public abstract LiveData<List<Event>> getAll();
 
     @Query("SELECT * FROM event WHERE id = :eventId")
     abstract LiveData<Event> getEvent(long eventId);
 
     @Query("DELETE FROM event")
-    abstract void clear();
-
-    @Update()
-    abstract void update(Event event);
+    public abstract void clear();
 
     @Transaction
-    void bulkUpdate(List<Event> events) {
+    public void bulkUpdate(List<Event> events) {
         for (Event event: events) {
             update(event);
         }

--- a/app/src/main/java/com/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventDao.java
@@ -16,7 +16,8 @@ import java.util.List;
 
 @Dao
 public abstract class EventDao implements AttractionDao<Event> {
-    @Query("SELECT * FROM event")
+    @Query("SELECT event.*, destination.name AS destinationName FROM event " +
+            "LEFT JOIN destination on destination.id = event.destination")
     public abstract LiveData<List<Event>> getAll();
 
     @Query("SELECT * FROM event WHERE id = :eventId")

--- a/app/src/main/java/com/gophillygo/app/data/EventViewModel.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventViewModel.java
@@ -1,0 +1,40 @@
+package com.gophillygo.app.data;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.ViewModel;
+
+import com.gophillygo.app.data.models.Event;
+import com.gophillygo.app.data.networkresource.Resource;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+
+public class EventViewModel extends ViewModel {
+
+    private final LiveData<Resource<List<Event>>> events;
+    private final DestinationRepository destinationRepository;
+
+    @Inject
+    public EventViewModel(DestinationRepository destinationRepository) {
+        this.destinationRepository = destinationRepository;
+        events = destinationRepository.loadEvents();
+    }
+
+    public LiveData<Event> getEvent(long eventId) {
+        return destinationRepository.getEvent(eventId);
+    }
+
+    public void updateEvent(Event event) {
+        destinationRepository.updateEvent(event);
+    }
+
+    public void updateMultipleEvents(List<Event> events) {
+        destinationRepository.updateMultipleEvents(events);
+    }
+
+    public LiveData<Resource<List<Event>>> getEvents() {
+        return events;
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
+++ b/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
@@ -7,7 +7,7 @@ import android.arch.persistence.room.TypeConverters;
 import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.Event;
 
-@Database(version=6, entities={Destination.class, Event.class})
+@Database(version=7, entities={Destination.class, Event.class})
 @TypeConverters({RoomConverters.class})
 public abstract class GpgDatabase extends RoomDatabase {
     abstract public DestinationDao destinationDao();

--- a/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
+++ b/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
@@ -6,7 +6,7 @@ import android.arch.persistence.room.TypeConverters;
 
 import com.gophillygo.app.data.models.Destination;
 
-@Database(version=4, entities={Destination.class})
+@Database(version=5, entities={Destination.class})
 @TypeConverters({RoomConverters.class})
 public abstract class GpgDatabase extends RoomDatabase {
     abstract public DestinationDao destinationDao();

--- a/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
+++ b/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
@@ -5,9 +5,11 @@ import android.arch.persistence.room.RoomDatabase;
 import android.arch.persistence.room.TypeConverters;
 
 import com.gophillygo.app.data.models.Destination;
+import com.gophillygo.app.data.models.Event;
 
-@Database(version=5, entities={Destination.class})
+@Database(version=6, entities={Destination.class, Event.class})
 @TypeConverters({RoomConverters.class})
 public abstract class GpgDatabase extends RoomDatabase {
     abstract public DestinationDao destinationDao();
+    abstract public EventDao eventDao();
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -15,13 +15,22 @@ public class Attraction {
     @PrimaryKey
     private final int id;
 
+    @ColumnInfo(index = true)
     private final int placeID;
+
+    @ColumnInfo(index = true)
     private final String name;
+
+    @ColumnInfo(index = true)
     private final boolean accessible;
     private final String image;
+
+    @ColumnInfo(index = true)
     private final boolean cycling;
     private final String description;
     private final int priority;
+
+    @ColumnInfo(index = true)
     private final ArrayList<String> activities;
 
     @ColumnInfo(name = "website_url")

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -1,0 +1,121 @@
+package com.gophillygo.app.data.models;
+
+import android.arch.persistence.room.ColumnInfo;
+import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.PrimaryKey;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+
+
+@Entity
+public class Attraction {
+
+    @PrimaryKey
+    private final int id;
+
+    private final int placeID;
+    private final String name;
+    private final boolean accessible;
+    private final String image;
+    private final boolean cycling;
+    private final String description;
+    private final int priority;
+    private final ArrayList<String> activities;
+
+    @ColumnInfo(name = "website_url")
+    @SerializedName("website_url")
+    private final String websiteUrl;
+
+    @ColumnInfo(name = "wide_image")
+    @SerializedName("wide_image")
+    private final String wideImage;
+
+    @ColumnInfo(name = "is_event")
+    @SerializedName("is_event")
+    private final boolean isEvent;
+
+    // timestamp is not final, as it is set on database save, and not by serializer
+    private long timestamp;
+
+    public Attraction(int id, int placeID, String name, boolean accessible, String image,
+                      boolean cycling, String description, int priority, String websiteUrl,
+                      String wideImage, boolean isEvent, ArrayList<String> activities) {
+        this.id = id;
+        this.placeID = placeID;
+        this.name = name;
+        this.accessible = accessible;
+        this.image = image;
+        this.cycling = cycling;
+        this.description = description;
+        this.priority = priority;
+        this.websiteUrl = websiteUrl;
+        this.wideImage = wideImage;
+        this.isEvent = isEvent;
+
+        this.activities = activities;
+    }
+
+    /**
+     * Timestamp entries. Timestamp value does not come from query result; it should be set
+     * on database save. Gson serializer will initialize value to zero.
+     *
+     * @param timestamp Time in milliseconds since Unix epoch
+     */
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getPlaceID() {
+        return placeID;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isAccessible() {
+        return accessible;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public boolean isCycling() {
+        return cycling;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public String getWebsiteUrl() {
+        return websiteUrl;
+    }
+
+    public String getWideImage() {
+        return wideImage;
+    }
+
+    public boolean isEvent() {
+        return isEvent;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public ArrayList<String> getActivities() {
+        return activities;
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/data/models/Destination.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Destination.java
@@ -3,7 +3,6 @@ package com.gophillygo.app.data.models;
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Embedded;
 import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -12,7 +11,7 @@ import java.util.ArrayList;
 
 
 @Entity
-public class Destination {
+public class Destination extends Attraction {
 
     private static final NumberFormat numberFormatter = NumberFormat.getNumberInstance();
     static {
@@ -20,49 +19,23 @@ public class Destination {
         numberFormatter.setMaximumFractionDigits(2);
     }
 
-    @PrimaryKey
-    private final int id;
-
-    private final int placeID;
-    private final String name;
-    private final boolean accessible;
-    private final String image;
     private final String city;
-    private final boolean cycling;
-    private final String description;
-    private final int priority;
     private final String state;
     private final String address;
-    private final ArrayList<String> activities;
 
     @Embedded
     private final DestinationLocation location;
-
-    @Embedded
-    private final DestinationAttributes attributes;
 
     @ColumnInfo(name = "watershed_alliance")
     @SerializedName("watershed_alliance")
     private final boolean watershedAlliance;
 
-    @ColumnInfo(name = "website_url")
-    @SerializedName("website_url")
-    private final String websiteUrl;
-
-    @ColumnInfo(name = "wide_image")
-    @SerializedName("wide_image")
-    private final String wideImage;
-
-    @ColumnInfo(name = "is_event")
-    @SerializedName("is_event")
-    private final boolean isEvent;
+    @Embedded
+    private final DestinationAttributes attributes;
 
     @ColumnInfo(name = "zipcode")
     @SerializedName("zipcode")
     private final String zipCode;
-
-    // timestamp is not final, as it is set on database save, and not by serializer
-    private long timestamp;
 
     // convenience property to track distance to each destination
     private float distance;
@@ -73,36 +46,19 @@ public class Destination {
                        int priority, String state, String address, DestinationLocation location,
                        DestinationAttributes attributes, boolean watershedAlliance, String websiteUrl,
                        String wideImage, boolean isEvent, ArrayList<String> activities) {
-        this.id = id;
-        this.placeID = placeID;
-        this.name = name;
-        this.accessible = accessible;
-        this.image = image;
+
+        // initialize Attraction
+        super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
+                wideImage, isEvent, activities);
+
         this.city = city;
-        this.cycling = cycling;
         this.zipCode = zipCode;
-        this.description = description;
-        this.priority = priority;
         this.state = state;
         this.address = address;
         this.watershedAlliance = watershedAlliance;
-        this.websiteUrl = websiteUrl;
-        this.wideImage = wideImage;
-        this.isEvent = isEvent;
 
         this.location = location;
         this.attributes = attributes;
-        this.activities = activities;
-    }
-
-    /**
-     * Timestamp entries. Timestamp value does not come from query result; it should be set
-     * on database save. Gson serializer will initialize value to zero.
-     *
-     * @param timestamp Time in milliseconds since Unix epoch
-     */
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
     }
 
     public void setDistance(float distance) {
@@ -115,40 +71,8 @@ public class Destination {
         this.formattedDistance = formattedDistance;
     }
 
-    public int getId() {
-        return id;
-    }
-
-    public int getPlaceID() {
-        return placeID;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public boolean isAccessible() {
-        return accessible;
-    }
-
-    public String getImage() {
-        return image;
-    }
-
     public String getCity() {
         return city;
-    }
-
-    public boolean isCycling() {
-        return cycling;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public int getPriority() {
-        return priority;
     }
 
     public String getState() {
@@ -167,28 +91,8 @@ public class Destination {
         return attributes;
     }
 
-    public boolean isWatershedAlliance() {
-        return watershedAlliance;
-    }
-
-    public String getWebsiteUrl() {
-        return websiteUrl;
-    }
-
-    public String getWideImage() {
-        return wideImage;
-    }
-
-    public boolean isEvent() {
-        return isEvent;
-    }
-
     public String getZipCode() {
         return zipCode;
-    }
-
-    public long getTimestamp() {
-        return timestamp;
     }
 
     public float getDistance() {
@@ -199,7 +103,7 @@ public class Destination {
         return formattedDistance;
     }
 
-    public ArrayList<String> getActivities() {
-        return activities;
+    public boolean isWatershedAlliance() {
+        return watershedAlliance;
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Destination.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Destination.java
@@ -10,7 +10,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 
 
-@Entity
+@Entity(inheritSuperIndices = true)
 public class Destination extends Attraction {
 
     private static final NumberFormat numberFormatter = NumberFormat.getNumberInstance();
@@ -22,6 +22,8 @@ public class Destination extends Attraction {
     private final String city;
     private final String state;
     private final String address;
+
+    private final ArrayList<String> categories;
 
     @Embedded
     private final DestinationLocation location;
@@ -45,7 +47,8 @@ public class Destination extends Attraction {
                        String city, boolean cycling, String zipCode, String description,
                        int priority, String state, String address, DestinationLocation location,
                        DestinationAttributes attributes, boolean watershedAlliance, String websiteUrl,
-                       String wideImage, boolean isEvent, ArrayList<String> activities) {
+                       String wideImage, boolean isEvent, ArrayList<String> activities,
+                       ArrayList<String> categories) {
 
         // initialize Attraction
         super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
@@ -59,6 +62,7 @@ public class Destination extends Attraction {
 
         this.location = location;
         this.attributes = attributes;
+        this.categories = categories;
     }
 
     public void setDistance(float distance) {
@@ -105,5 +109,9 @@ public class Destination extends Attraction {
 
     public boolean isWatershedAlliance() {
         return watershedAlliance;
+    }
+
+    public ArrayList<String> getCategories() {
+        return categories;
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/DestinationQueryResponse.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/DestinationQueryResponse.java
@@ -10,17 +10,16 @@ import java.util.List;
 public class DestinationQueryResponse {
     private final List<Destination> destinations;
 
-    // TODO: create separate type for events
-    private final List<Destination> events;
+    private final List<Event> events;
 
     public List<Destination> getDestinations() {
         return destinations;
     }
 
-    public List<Destination> getEvents() { return events; }
+    public List<Event> getEvents() { return events; }
 
     @SuppressWarnings("unused")
-    public DestinationQueryResponse(List<Destination> destinations, List<Destination> events) {
+    public DestinationQueryResponse(List<Destination> destinations, List<Event> events) {
         this.destinations = destinations;
         this.events = events;
     }

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -26,7 +26,7 @@ public class Event extends Attraction {
     private final Integer destination;
 
     // fetch name of related destination from database into this property
-    private String destinationName;
+    private final String destinationName;
 
     @ColumnInfo(name = "start_date", index = true)
     @SerializedName("start_date")

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -1,0 +1,61 @@
+package com.gophillygo.app.data.models;
+
+import android.arch.persistence.room.ColumnInfo;
+import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.ForeignKey;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+
+import static android.arch.persistence.room.ForeignKey.SET_NULL;
+
+
+@Entity(foreignKeys = @ForeignKey(entity = Destination.class,
+        parentColumns = "id",
+        childColumns = "destination",
+        deferred = true,
+        onDelete = SET_NULL),
+        inheritSuperIndices = true)
+
+
+public class Event extends Attraction {
+
+    // using Integer instead of int so it may be nullable
+    @ColumnInfo(index = true)
+    private final Integer destination;
+
+    @ColumnInfo(name = "start_date", index = true)
+    @SerializedName("start_date")
+    private final String startDate;
+
+    @ColumnInfo(name = "end_date", index = true)
+    @SerializedName("end_date")
+    private final String endDate;
+
+
+    public Event(int id, int placeID, String name, boolean accessible, String image,
+                 boolean cycling, String description, int priority, String websiteUrl,
+                 String wideImage, boolean isEvent, ArrayList<String> activities,
+                 Integer destination, String startDate, String endDate) {
+
+        // initialize Attraction
+        super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
+                wideImage, isEvent, activities);
+
+        this.destination = destination;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public Integer getDestination() {
+        return destination;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -3,6 +3,7 @@ package com.gophillygo.app.data.models;
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
 import android.arch.persistence.room.ForeignKey;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
@@ -24,6 +25,9 @@ public class Event extends Attraction {
     @ColumnInfo(index = true)
     private final Integer destination;
 
+    // fetch name of related destination from database into this property
+    private String destinationName;
+
     @ColumnInfo(name = "start_date", index = true)
     @SerializedName("start_date")
     private final String startDate;
@@ -36,7 +40,7 @@ public class Event extends Attraction {
     public Event(int id, int placeID, String name, boolean accessible, String image,
                  boolean cycling, String description, int priority, String websiteUrl,
                  String wideImage, boolean isEvent, ArrayList<String> activities,
-                 Integer destination, String startDate, String endDate) {
+                 Integer destination, String startDate, String endDate, String destinationName) {
 
         // initialize Attraction
         super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
@@ -45,6 +49,11 @@ public class Event extends Attraction {
         this.destination = destination;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.destinationName = destinationName;
+    }
+
+    public String getDestinationName() {
+        return destinationName;
     }
 
     public Integer getDestination() {

--- a/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -1,0 +1,78 @@
+package com.gophillygo.app.data.networkresource;
+
+import android.arch.lifecycle.LiveData;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.gophillygo.app.data.DestinationDao;
+import com.gophillygo.app.data.DestinationWebservice;
+import com.gophillygo.app.data.EventDao;
+import com.gophillygo.app.data.models.Attraction;
+import com.gophillygo.app.data.models.Destination;
+import com.gophillygo.app.data.models.DestinationQueryResponse;
+import com.gophillygo.app.data.models.Event;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared network query manager between events and destinations (attractions).
+ * Subclass to get LiveData responses for either destinations or events.
+ */
+
+abstract public class AttractionNetworkBoundResource<T extends Attraction>
+        extends NetworkBoundResource<List<T>, DestinationQueryResponse> {
+
+    // maximum rate at which to refresh data from network
+    private static final long RATE_LIMIT = TimeUnit.MINUTES.toMillis(15);
+
+    private final DestinationWebservice webservice;
+    private final DestinationDao destinationDao;
+    private final EventDao eventDao;
+
+    public AttractionNetworkBoundResource(DestinationWebservice webservice,
+                                          DestinationDao destinationDao,
+                                          EventDao eventDao) {
+        this.webservice = webservice;
+        this.destinationDao = destinationDao;
+        this.eventDao = eventDao;
+    }
+
+    @Override
+    protected void saveCallResult(@NonNull DestinationQueryResponse response) {
+        Long timestamp = System.currentTimeMillis();
+
+        // clear out existing database entries before adding new ones
+        destinationDao.clear();
+        eventDao.clear();
+
+        // save destinations
+        for (Destination item: response.getDestinations()) {
+            item.setTimestamp(timestamp);
+            destinationDao.save(item);
+        }
+
+        // save events
+        for (Event item: response.getEvents()) {
+            item.setTimestamp(timestamp);
+            eventDao.save(item);
+        }
+    }
+
+    @Override
+    protected boolean shouldFetch(@Nullable List<T> data) {
+        if (data == null || data.isEmpty()) {
+            return true;
+        }
+        Attraction first = data.get(0);
+        return System.currentTimeMillis() - first.getTimestamp() > RATE_LIMIT;
+    }
+
+    @NonNull @Override
+    protected LiveData<ApiResponse<DestinationQueryResponse>> createCall() {
+        return webservice.getDestinations();
+    }
+
+    @NonNull @Override
+    abstract protected LiveData<List<T>> loadFromDb();
+}

--- a/app/src/main/java/com/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppComponent.java
@@ -2,6 +2,7 @@ package com.gophillygo.app.di;
 
 import android.app.Application;
 
+import com.gophillygo.app.EventsListActivity;
 import com.gophillygo.app.GoPhillyGoApp;
 import com.gophillygo.app.PlaceDetailActivity;
 import com.gophillygo.app.PlacesListActivity;
@@ -21,9 +22,10 @@ import dagger.android.AndroidInjectionModule;
 @Component(modules = {
         AndroidInjectionModule.class,
         AppModule.class,
+        EventsListActivityModule.class,
         HomeActivityModule.class,
-        PlacesListActivityModule.class,
-        PlaceDetailActivityModule.class
+        PlaceDetailActivityModule.class,
+        PlacesListActivityModule.class
 })
 public interface AppComponent {
     @Component.Builder

--- a/app/src/main/java/com/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppComponent.java
@@ -2,10 +2,7 @@ package com.gophillygo.app.di;
 
 import android.app.Application;
 
-import com.gophillygo.app.EventsListActivity;
 import com.gophillygo.app.GoPhillyGoApp;
-import com.gophillygo.app.PlaceDetailActivity;
-import com.gophillygo.app.PlacesListActivity;
 
 import javax.inject.Singleton;
 

--- a/app/src/main/java/com/gophillygo/app/di/AppModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppModule.java
@@ -5,6 +5,7 @@ import android.arch.persistence.room.Room;
 
 import com.gophillygo.app.data.DestinationDao;
 import com.gophillygo.app.data.DestinationWebservice;
+import com.gophillygo.app.data.EventDao;
 import com.gophillygo.app.data.GpgDatabase;
 import com.gophillygo.app.data.networkresource.LiveDataCallAdapterFactory;
 
@@ -61,5 +62,11 @@ class AppModule {
     @Provides
     DestinationDao provideDestinationDao(GpgDatabase db) {
         return db.destinationDao();
+    }
+
+    @Singleton
+    @Provides
+    EventDao provideEventDao(GpgDatabase db) {
+        return db.eventDao();
     }
 }

--- a/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
@@ -1,0 +1,14 @@
+package com.gophillygo.app.di;
+
+import com.gophillygo.app.EventsListActivity;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+
+@Module
+public abstract class EventsListActivityModule {
+    @SuppressWarnings("unused")
+    @ContributesAndroidInjector
+    abstract EventsListActivity contributeEventsListActivity();
+}

--- a/app/src/main/java/com/gophillygo/app/di/ViewModelModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/ViewModelModule.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
 
 import com.gophillygo.app.data.DestinationViewModel;
+import com.gophillygo.app.data.EventViewModel;
 
 import dagger.Binds;
 import dagger.Module;
@@ -23,6 +24,11 @@ public abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(DestinationViewModel.class)
     abstract ViewModel bindDestinationViewModel(DestinationViewModel destinationViewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(EventViewModel.class)
+    abstract ViewModel bindEventViewModel(EventViewModel eventViewModel);
 
     @Binds
     abstract ViewModelProvider.Factory bindViewModelFactory(GpgViewModelFactory factory);

--- a/app/src/main/res/layout/activity_events_list.xml
+++ b/app/src/main/res/layout/activity_events_list.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.gophillygo.app.EventsListActivity">
+
+<RelativeLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/events_list_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:fitsSystemWindows="true"
+        android:elevation="0dp"
+        android:background="@color/color_primary"
+        app:title="@string/events_list_title"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        tools:targetApi="lollipop" />
+
+    <LinearLayout
+        android:id="@+id/events_list_filter_button_bar"
+        android:layout_below="@+id/events_list_toolbar"
+        android:background="@color/color_primary"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        android:weightSum="3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/events_list_filter_button"
+            android:textColor="@color/color_white"
+            android:layout_gravity="start"
+            android:layout_weight="1"
+            android:background="@drawable/toggle_button_toolbar_unchecked"
+            android:drawableStart="@drawable/ic_filter_list_white_24px"
+            style="@style/FilterBarButton"
+            android:text="@string/filter_button_title" />
+
+        <Space
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <com.gophillygo.app.GpgToolbarToggleButton
+            android:id="@+id/events_list_want_to_go_filter_button"
+            android:text="@string/place_want_to_go_option"
+            android:layout_weight="1"
+            android:drawableStart="@drawable/toggle_button_toolbar_flag_drawable_selector"
+            style="@style/FilterBarButton"
+            android:textColor="@drawable/toggle_button_toolbar_text_selector"
+            android:layout_gravity="end" />
+    </LinearLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/events_list_recycler_view"
+        android:layout_below="@id/events_list_filter_button_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+    </android.support.v7.widget.RecyclerView>
+
+</RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -13,9 +13,13 @@
         style="@style/Base.TextAppearance.AppCompat.Title"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/event_list_item_name_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="start"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:textAllCaps="true"
+        android:gravity="center"
         android:padding="2dp" />
 
     <TextView
@@ -25,6 +29,8 @@
         app:layout_constraintTop_toBottomOf="@+id/event_month_label"
         app:layout_constraintBottom_toTopOf="@+id/event_day_of_week_label"
         app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="start"
@@ -33,13 +39,17 @@
     <TextView
         android:id="@+id/event_day_of_week_label"
         style="@style/Base.TextAppearance.AppCompat.Title"
-        android:textColor="@color/color_text_dark_grey"
+        android:textColor="@color/color_text_light_grey"
         app:layout_constraintTop_toBottomOf="@+id/event_day_of_month_label"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:layout_width="wrap_content"
+        app:layout_constraintEnd_toStartOf="@id/event_list_destination_name"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:gravity="start"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:textAllCaps="true"
+        android:gravity="center"
         android:padding="2dp" />
 
     <TextView
@@ -49,34 +59,41 @@
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
         app:layout_constraintLeft_toRightOf="@id/event_day_of_month_label"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:gravity="start"
         android:padding="2dp" />
 
     <TextView
         android:id="@+id/event_list_destination_name"
         style="@style/TextAppearance.AppCompat.Medium"
-        android:layout_width="wrap_content"
+        android:textColor="@color/color_text_dark_grey"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@+id/event_list_item_name_label"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
         app:layout_constraintLeft_toRightOf="@id/event_day_of_month_label"
+        app:layout_constraintBottom_toTopOf="@+id/event_list_item_options_button"
         app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:padding="2dp"
         android:gravity="start" />
 
     <TextView
         android:id="@+id/event_list_time"
         style="@style/TextAppearance.AppCompat.Medium"
-        android:textColor="@color/color_text_dark_grey"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/event_list_destination_name"
+        app:layout_constraintTop_toBottomOf="@id/event_list_destination_name"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/event_list_item_options_button"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
-        app:layout_constraintBottom_toTopOf="@+id/event_list_item_options_button"
+        android:text="@string/app_name"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
         android:padding="2dp"
         android:gravity="start" />
 

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -6,8 +6,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/color_white"
     android:paddingBottom="10dp"
-    android:layout_margin="10dp"
-    xmlns:tools="http://schemas.android.com/tools">
+    android:layout_margin="10dp">
 
     <TextView
         android:id="@+id/event_month_label"
@@ -22,7 +21,7 @@
     <TextView
         android:id="@+id/event_day_of_month_label"
         style="@style/Base.TextAppearance.AppCompat.Title"
-        android:textSize="14sp"
+        android:textSize="50sp"
         app:layout_constraintTop_toBottomOf="@+id/event_month_label"
         app:layout_constraintBottom_toTopOf="@+id/event_day_of_week_label"
         app:layout_constraintStart_toStartOf="parent"
@@ -48,6 +47,8 @@
         style="@style/Base.TextAppearance.AppCompat.Title"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        app:layout_constraintLeft_toRightOf="@id/event_day_of_month_label"
+        app:layout_constraintEnd_toEndOf="parent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="start"
@@ -60,6 +61,8 @@
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@+id/event_list_item_name_label"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        app:layout_constraintLeft_toRightOf="@id/event_day_of_month_label"
+        app:layout_constraintEnd_toEndOf="parent"
         android:padding="2dp"
         android:gravity="start" />
 
@@ -73,13 +76,13 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/event_list_item_options_button"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        app:layout_constraintBottom_toTopOf="@+id/event_list_item_options_button"
         android:padding="2dp"
         android:gravity="start" />
 
     <android.support.v7.widget.AppCompatImageButton
         app:backgroundTint="@color/color_white"
         android:id="@+id/event_list_item_options_button"
-        app:layout_constraintTop_toBottomOf="@+id/event_list_destination_name"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:src="@drawable/ic_add_black_24dp"

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -83,7 +83,7 @@
         android:gravity="start" />
 
     <TextView
-        android:id="@+id/event_list_time"
+        android:id="@+id/event_list_item_time"
         style="@style/TextAppearance.AppCompat.Medium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -91,7 +91,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/event_list_item_options_button"
         app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
-        android:text="@string/app_name"
         android:layout_marginStart="4dp"
         android:layout_marginEnd="4dp"
         android:padding="2dp"

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/color_white"
+    android:paddingBottom="10dp"
+    android:layout_margin="10dp"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <TextView
+        android:id="@+id/event_month_label"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:padding="2dp" />
+
+    <TextView
+        android:id="@+id/event_day_of_month_label"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@+id/event_month_label"
+        app:layout_constraintBottom_toTopOf="@+id/event_day_of_week_label"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:padding="2dp" />
+
+    <TextView
+        android:id="@+id/event_day_of_week_label"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        android:textColor="@color/color_text_dark_grey"
+        app:layout_constraintTop_toBottomOf="@+id/event_day_of_month_label"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:padding="2dp" />
+
+    <TextView
+        android:id="@+id/event_list_item_name_label"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:padding="2dp" />
+
+    <TextView
+        android:id="@+id/event_list_destination_name"
+        style="@style/TextAppearance.AppCompat.Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/event_list_item_name_label"
+        app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        android:padding="2dp"
+        android:gravity="start" />
+
+    <TextView
+        android:id="@+id/event_list_time"
+        style="@style/TextAppearance.AppCompat.Medium"
+        android:textColor="@color/color_text_dark_grey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/event_list_destination_name"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/event_list_item_options_button"
+        app:layout_constraintStart_toEndOf="@id/event_day_of_month_label"
+        android:padding="2dp"
+        android:gravity="start" />
+
+    <android.support.v7.widget.AppCompatImageButton
+        app:backgroundTint="@color/color_white"
+        android:id="@+id/event_list_item_options_button"
+        app:layout_constraintTop_toBottomOf="@+id/event_list_destination_name"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:src="@drawable/ic_add_black_24dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/filter_modal.xml
+++ b/app/src/main/res/layout/filter_modal.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@color/color_background_grey">
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:id="@+id/filter_modal_top"

--- a/app/src/main/res/menu/events_list_menu.xml
+++ b/app/src/main/res/menu/events_list_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_event_place"
+        android:orderInCategory="1"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_place_white_24px"
+        android:title="@string/menu_action_event_place"/>
+
+    <item
+        android:id="@+id/action_event_map"
+        android:orderInCategory="2"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_map_white_24px"
+        android:title="@string/menu_action_map"/>
+
+    <item
+        android:id="@+id/action_event_search"
+        android:orderInCategory="3"
+        app:showAsAction="ifRoom"
+        android:title="@string/menu_search_action"
+        android:icon="@drawable/ic_search_white_24px"/>
+</menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,5 @@
     <color name="color_background_grey">#C5C8CC</color>
     <color name="color_white">#ffffff</color>
     <color name="color_text_dark_grey">#263238</color>
+    <color name="color_text_light_grey">#727E84</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="menu_action_logout">Sign out</string>
     <string name="menu_action_events">Go to events</string>
     <string name="menu_action_map">See map</string>
+    <string name="menu_action_event_place">View Destination</string>
 
     <!-- place option menu items -->
     <string name="place_not_interested_option">Not interested</string>
@@ -18,6 +19,7 @@
     <string name="carousel_nearby_label">Nearby</string>
 
     <string name="places_list_title">Places</string>
+    <string name="events_list_title">Events</string>
 
     <!-- filtering -->
     <string name="reset_button">Reset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,7 @@
 
     <string name="place_detail_description_expand">SHOW MORE</string>
     <string name="place_detail_description_collapse">SHOW LESS</string>
+
+    <!-- event list -->
+    <string name="event_list_item_time_range">%s - %s</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 06 09:54:09 EST 2018
+#Tue Mar 27 10:43:45 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
## Overview

Fetch events when fetching destinations. Display events in a list ([wireframe](https://marvelapp.com/4c295bb/screen/37237010)).

## Demo

![screenshot_1522261801](https://user-images.githubusercontent.com/960264/38048972-eafd566a-3294-11e8-940a-0b9ffda2c1f8.png)


## Notes

Events and destinations share most properties, so their models share a base `Attraction` class.


## Testing

 - Click the first grid box item for "events" on the app home screen
 - Should get list of events, formatted as expected
 - Related destination name (if any) should display
 - Filter popover should function as it does on the destinations list view (filtering not yet implemented)

Closes #17 

