### PR TITLE
Feature/kak/location service#9

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="dagger.android.ContributesAndroidInjector" />
+    </list>
+  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,11 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:cardview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    // Android Play services libraries
+    def playServicesVersion = '12.0.1'
+    implementation "com.google.android.gms:play-services-location:$playServicesVersion"
+    implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
     // Carousel
     implementation 'com.github.flibbertigibbet:carouselview:1.0.5'
     // Badges
@@ -81,7 +85,3 @@ dependencies {
     // Test helpers for Room
     testImplementation "android.arch.persistence.room:testing:$roomVersion"
 }
-
-
-
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation "android.arch.persistence.room:runtime:$roomVersion"
     annotationProcessor "android.arch.persistence.room:compiler:$roomVersion"
     // Android UI libraries
-    def supportVersion = '27.1.0'
+    def supportVersion = '27.1.1'
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:cardview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"

--- a/app/src/androidTest/java/com/gophillygo/app/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/gophillygo/app/ExampleInstrumentedTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedTest {
     @Test
-    public void useAppContext() throws Exception {
+    public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.gophillygo.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!--
     Allows Glide to monitor connectivity status and restart failed requests if users go from a
     a disconnected to a connected network state.
@@ -27,12 +28,14 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Accepts only the top-level URI "https://gophillygo.org” -->
-                <data android:scheme="https"
+                <data
+                    android:host="gophillygo.org"
                     android:path="/"
-                    android:host="gophillygo.org" />
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <activity
@@ -50,7 +53,8 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.gophillygo.app.PlacesListActivity" />
         </activity>
-        <activity android:name=".EventsListActivity"
+        <activity
+            android:name=".EventsListActivity"
             android:label="@string/events_list_title"
             android:parentActivityName=".HomeActivity">
             <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:supportsRtl="true"
         android:theme="@style/GpgAppTheme"
         android:value="GlideModule">
-        <activity android:name=".HomeActivity">
+        <activity android:name=".activities.HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -39,27 +39,27 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".PlacesListActivity"
+            android:name=".activities.PlacesListActivity"
             android:label="@string/places_list_title"
-            android:parentActivityName=".HomeActivity">
+            android:parentActivityName=".activities.HomeActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.gophillygo.app.HomeActivity" />
+                android:value="com.gophillygo.app.activities.HomeActivity" />
         </activity>
         <activity
-            android:name=".PlaceDetailActivity"
-            android:parentActivityName=".PlacesListActivity">
+            android:name=".activities.PlaceDetailActivity"
+            android:parentActivityName=".activities.PlacesListActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.gophillygo.app.PlacesListActivity" />
+                android:value="com.gophillygo.app.activities.PlacesListActivity" />
         </activity>
         <activity
-            android:name=".EventsListActivity"
+            android:name=".activities.EventsListActivity"
             android:label="@string/events_list_title"
-            android:parentActivityName=".HomeActivity">
+            android:parentActivityName=".activities.HomeActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.gophillygo.app.HomeActivity" />
+                android:value="com.gophillygo.app.activities.HomeActivity" />
         </activity>
     </application>
 

--- a/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
@@ -1,0 +1,205 @@
+package com.gophillygo.app.activities;
+
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+import com.gophillygo.app.data.DestinationViewModel;
+import com.gophillygo.app.data.models.Destination;
+import com.gophillygo.app.data.models.DestinationInfo;
+import com.gophillygo.app.data.models.DestinationLocation;
+import com.gophillygo.app.data.networkresource.Status;
+import com.gophillygo.app.di.GpgViewModelFactory;
+import com.gophillygo.app.utils.GpgLocationUtils;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+public abstract class BaseAttractionActivity extends AppCompatActivity implements GpgLocationUtils.LocationUpdateListener {
+
+    private static final String LOG_LABEL = "BaseAttractionActivity";
+    private static final String DUMMY_LOCATION_PROVIDER = "gophillygo";
+
+    private static final float METERS_TO_MILES = 0.000621371192f;
+
+    // maximum number of nearby destinations to show in carousel
+    protected static final int NEAREST_DESTINATION_COUNT = 8;
+
+    // City Hall
+    private static final double DEFAULT_LATITUDE = 39.954888;
+    private static final double DEFAULT_LONGITUDE = -75.163206;
+
+    private Location currentLocation;
+    private boolean locationHasChanged = false; // true if distances to new location not yet set
+
+    protected List<DestinationInfo> destinationInfos;
+    private List<DestinationInfo> nearestDestinations;
+
+    @Inject
+    GpgViewModelFactory viewModelFactory;
+    @SuppressWarnings("WeakerAccess")
+    DestinationViewModel viewModel;
+
+
+    private void setDefaultLocation() {
+        Log.w(LOG_LABEL, "Using City Hall as default location");
+        currentLocation = new Location(DUMMY_LOCATION_PROVIDER);
+        currentLocation.setLatitude(DEFAULT_LATITUDE);
+        currentLocation.setLongitude(DEFAULT_LONGITUDE);
+    }
+
+    private void fetchLastLocationOrUseDefault() {
+        // request location, and if request fails, use default
+        if (!GpgLocationUtils.getLastKnownLocation(new WeakReference<>(this), this)) {
+            setDefaultLocation();
+        }
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        fetchLastLocationOrUseDefault();
+
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+                .get(DestinationViewModel.class);
+        viewModel.getDestinations().observe(this, destinationResource -> {
+            // shouldn't happen
+            if (destinationResource == null) {
+                Log.e(LOG_LABEL, "No ApiResponse wrapper returned");
+                return;
+            }
+
+            // if querying from server, state may update with LOADING status before it finishes
+            if (!destinationResource.status.equals(Status.SUCCESS)) {
+                return;
+            }
+
+            if (destinationResource.data == null || destinationResource.data.isEmpty()) {
+                Log.e(LOG_LABEL, "Destination query returned, but found no results");
+                return;
+            }
+
+            destinationInfos = destinationResource.data;
+            Log.d(LOG_LABEL, "Got destination data");
+            nearestDestinations = findNearestDestinations();
+            locationOrDestinationsChanged();
+        });
+    }
+
+    @NonNull
+    private List<DestinationInfo> findNearestDestinations() {
+
+        if (currentLocation == null || destinationInfos == null || destinationInfos.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // set distance to each location, if not set already
+        int totalDestinations = destinationInfos.size();
+
+        // check if data needs to be updated: only if destinations not set yet, or location changed
+        boolean update = true;
+        DestinationInfo firstDestination = destinationInfos.get(0);
+        if (firstDestination.getDestination().getDistance() > 0) {
+            // have distances; only update if location changed
+            if (!locationHasChanged) {
+                Log.d(LOG_LABEL, "Have distances and location unchanged; not updating destinations");
+                update = false;
+            }
+        }
+
+        if (update) {
+            for (DestinationInfo info : destinationInfos) {
+                Destination dest = info.getDestination();
+                Location location = new Location(DUMMY_LOCATION_PROVIDER);
+                DestinationLocation coordinates = dest.getLocation();
+                location.setLatitude(coordinates.getY());
+                location.setLongitude(coordinates.getX());
+                float distanceInMeters = currentLocation.distanceTo(location);
+                dest.setDistance(distanceInMeters * METERS_TO_MILES);
+            }
+
+            // now distances have been updated, unset flag for need to update
+            locationHasChanged = false;
+            Log.d(LOG_LABEL, "updating destinations with distances");
+            viewModel.updateMultipleDestinations(destinationInfos);
+        }
+
+        // return the nearest destinations
+        int numDestinations = NEAREST_DESTINATION_COUNT;
+        if (totalDestinations < numDestinations) {
+            numDestinations = totalDestinations;
+        }
+
+        return destinationInfos.subList(0, numDestinations - 1);
+    }
+
+    /**
+     * Override to listen to changes to data: either location or destinations source data.
+     */
+    public void locationOrDestinationsChanged() { }
+
+    /**
+     * Callback for {@link GpgLocationUtils.LocationUpdateListener}
+     *
+     * @param location Coordinates of last known location for the device.
+     */
+    @Override
+    public void locationFound(Location location) {
+
+        if (location == null || location.equals(currentLocation)) {
+            Log.d(LOG_LABEL, "Location null, or unchanged.");
+            return;
+        }
+
+        Log.d(LOG_LABEL, "location found: " + location.toString());
+        currentLocation = location;
+        locationHasChanged = true;
+        nearestDestinations = findNearestDestinations();
+        locationOrDestinationsChanged();
+    }
+
+    /**
+     * Get a destination by offset in list of destinations ordered by distance.
+     *
+     * @param position Offset of destination in list
+     */
+    public Destination getNearestDestination(int position) {
+        try {
+            return nearestDestinations.get(position).getDestination();
+        } catch (IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    public int getNearestDestinationSize() {
+        if (nearestDestinations == null) {
+            return 0;
+        }
+        return nearestDestinations.size();
+    }
+
+    /**
+     * Handle the location services permission request initiated, if needed.
+     */
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == GpgLocationUtils.PERMISSION_REQUEST_ID) {
+            if (grantResults.length > 0) {
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    Log.d(LOG_LABEL, "Re-requesting location after getting permissions");
+                    fetchLastLocationOrUseDefault();
+                } else if (grantResults[0] == PackageManager.PERMISSION_DENIED) {
+                    GpgLocationUtils.displayPermissionRequestRationale(getApplicationContext());
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
@@ -1,5 +1,6 @@
 package com.gophillygo.app.activities;
 
+import android.app.Activity;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.pm.PackageManager;
 import android.location.Location;
@@ -23,6 +24,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+/**
+ * Base activity that requests last known location and destination data when opened;
+ * if either change, updates the distances to the destinations and calls
+ * `locationOrDestinationsChanged`.
+ */
 public abstract class BaseAttractionActivity extends AppCompatActivity implements GpgLocationUtils.LocationUpdateListener {
 
     private static final String LOG_LABEL = "BaseAttractionActivity";
@@ -58,7 +64,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity implement
 
     private void fetchLastLocationOrUseDefault() {
         // request location, and if request fails, use default
-        if (!GpgLocationUtils.getLastKnownLocation(new WeakReference<>(this), this)) {
+        if (!GpgLocationUtils.getLastKnownLocation(new WeakReference<>(this))) {
             setDefaultLocation();
         }
     }

--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -1,4 +1,4 @@
-package com.gophillygo.app;
+package com.gophillygo.app.activities;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModelProviders;
@@ -12,6 +12,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.EventsListAdapter;
 import com.gophillygo.app.data.EventViewModel;
 import com.gophillygo.app.data.models.AttractionInfo;

--- a/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
@@ -1,4 +1,4 @@
-package com.gophillygo.app;
+package com.gophillygo.app.activities;
 
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -8,6 +8,8 @@ import android.support.v7.widget.Toolbar;
 import android.widget.Button;
 
 import com.gophillygo.app.data.models.Filter;
+import com.gophillygo.app.FilterDialog;
+import com.gophillygo.app.R;
 
 import cn.nekocode.badge.BadgeDrawable;
 
@@ -76,5 +78,6 @@ public abstract class FilterableListActivity extends AppCompatActivity
         } else {
             filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
         }
+
     }
 }

--- a/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
@@ -1,78 +1,40 @@
 package com.gophillygo.app.activities;
 
-import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.location.Location;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.GridView;
 
 import com.gophillygo.app.CarouselViewListener;
 import com.gophillygo.app.R;
-import com.gophillygo.app.activities.EventsListActivity;
-import com.gophillygo.app.activities.PlacesListActivity;
 import com.gophillygo.app.adapters.PlaceCategoryGridAdapter;
-import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.Destination;
-import com.gophillygo.app.data.models.DestinationInfo;
-import com.gophillygo.app.data.models.DestinationLocation;
-import com.gophillygo.app.data.networkresource.Status;
-import com.gophillygo.app.di.GpgViewModelFactory;
-import com.gophillygo.app.utils.GpgLocationUtils;
 import com.synnapps.carouselview.CarouselView;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.List;
 
-import javax.inject.Inject;
-
-
-public class HomeActivity extends AppCompatActivity implements GpgLocationUtils.LocationUpdateListener {
+public class HomeActivity extends BaseAttractionActivity {
 
     private static final String LOG_LABEL = "HomeActivity";
 
-    // maximum number of nearby destinations to show in carousel
-    private static final int CAROUSEL_MAX_DESTINATION_COUNT = 8;
-
-    private static final float METERS_TO_MILES = 0.000621371192f;
-
-    private LayoutInflater inflater;
-
     private CarouselView carouselView;
-    private GridView gridView;
-    private Toolbar toolbar;
 
-    @Inject
-    GpgViewModelFactory viewModelFactory;
-    @SuppressWarnings("WeakerAccess")
-    DestinationViewModel viewModel;
-
-    private List<DestinationInfo> destinationInfos;
-    private List<DestinationInfo> nearestDestinations;
-    private Location currentLocation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
+        Log.d(LOG_LABEL, "onCreate");
 
-        inflater = getLayoutInflater();
-
-        toolbar = findViewById(R.id.home_toolbar);
+        Toolbar toolbar = findViewById(R.id.home_toolbar);
         // disable default app name title display
         toolbar.setTitle("");
         setSupportActionBar(toolbar);
 
-        gridView = findViewById(R.id.home_grid_view);
+        GridView gridView = findViewById(R.id.home_grid_view);
         gridView.setAdapter(new PlaceCategoryGridAdapter(this));
         gridView.setOnItemClickListener((parent, v, position, id) -> clickedGridItem(position));
 
@@ -81,76 +43,41 @@ public class HomeActivity extends AppCompatActivity implements GpgLocationUtils.
         carouselView.setImageClickListener(position ->
                 Log.d(LOG_LABEL, "Clicked item: "+ position));
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
-                .get(DestinationViewModel.class);
-        viewModel.getDestinations().observe(this, destinationResource -> {
-            // shouldn't happen
-            if (destinationResource == null) {
-                Log.e(LOG_LABEL, "No ApiResponse wrapper returned");
-                return;
-            }
-
-            // if querying from server, state may update with LOADING status before it finishes
-            if (!destinationResource.status.equals(Status.SUCCESS)) {
-                return;
-            }
-
-            if (destinationResource.data == null || destinationResource.data.isEmpty()) {
-                Log.e(LOG_LABEL, "Destination query returned, but found no results");
-                return;
-            }
-
-            // request location
-            if (!GpgLocationUtils.getLastKnownLocation(new WeakReference<>(this), this)) {
-                // if last location can't be found right now for some reason, use default
-                // set to dummy location: City Hall
-                // TODO: remove/replace
-                currentLocation = new Location("dummy");
-                currentLocation.setLatitude(39.954888);
-                currentLocation.setLongitude(-75.163206);
-            }
-
-            destinationInfos = destinationResource.data;
-            int numDestinations = CAROUSEL_MAX_DESTINATION_COUNT;
-            if (destinationInfos.size() < numDestinations) {
-                numDestinations = destinationInfos.size();
-            }
-            nearestDestinations = destinationInfos.subList(0, numDestinations - 1);
-            viewModel.getDestinations().removeObservers(this);
-        });
+        // initialize carousel if destinations already loaded
+        locationOrDestinationsChanged();
     }
 
-    @NonNull
-    private List<DestinationInfo> findNearestDestinations() {
-        // TODO: #9 move logic to set distances once location service set up
-        // set distance to each location, if not set already
-        int totalDestinations = destinationInfos.size();
-        // TODO: also update if location changed, but causes live data to reload in a loop
-        //Destination firstDestination = destinationInfos.get(0).getDestination();
-        //if (firstDestination.getDistance() == 0) {
-        List<Destination> destinations = new ArrayList<>(totalDestinations);
-        for (DestinationInfo info : destinationInfos) {
-            destinations.add(info.getDestination());
-        }
+    @Override
+    public void locationOrDestinationsChanged() {
+        Log.d(LOG_LABEL, "Location or destinations changed; setting up carousel");
+        // set up carousel with nearest destinations
+        if (getNearestDestinationSize() > 0) {
+            setUpCarousel();
+        } else {
+            Log.w(LOG_LABEL, "No nearest destinations yet in locationOrDestinationChanged");
 
-        for (Destination dest: destinations) {
-            Location location = new Location("dummy");
-            DestinationLocation coordinates = dest.getLocation();
-            location.setLatitude(coordinates.getY());
-            location.setLongitude(coordinates.getX());
-            float distanceInMeters = currentLocation.distanceTo(location);
-            dest.setDistance(distanceInMeters * METERS_TO_MILES);
         }
+    }
 
-        // update destinations all at once, so LiveData observer only triggers once
-        viewModel.updateMultipleDestinations(destinations);
+    private void setUpCarousel() {
+        Log.d(LOG_LABEL, "set up carousel with size: " + getNearestDestinationSize());
 
-        // return the nearest destinations
-        int numDestinations = CAROUSEL_MAX_DESTINATION_COUNT;
-        if (totalDestinations < numDestinations) {
-            numDestinations = totalDestinations;
+        carouselView.pauseCarousel();
+        carouselView.setViewListener(new CarouselViewListener(this, true) {
+            @Override
+            public Destination getDestinationAt(int position) {
+                return getNearestDestination(position);
+            }
+        });
+        carouselView.setPageCount(getNearestDestinationSize());
+
+        // prompt carousel to refresh currently displayed item
+        if (getNearestDestinationSize() > 0) {
+            carouselView.setCurrentItem(0);
+            carouselView.playCarousel();
+        } else {
+            Log.d(LOG_LABEL, "Nearest destinations collection empty; nothing to put in carousel.");
         }
-        return destinationInfos.subList(0, numDestinations - 1);
     }
 
     @Override
@@ -208,48 +135,6 @@ public class HomeActivity extends AppCompatActivity implements GpgLocationUtils.
                 // go to places list
                 // TODO: #18 filter list based on selected grid item
                 startActivity(new Intent(this, PlacesListActivity.class));
-        }
-    }
-
-    @Override
-    public void locationFound(Location location) {
-        if (location == null) {
-            Log.w(LOG_LABEL, "Have no found location returned.");
-        } else {
-            Log.d(LOG_LABEL, "location found!");
-        }
-        currentLocation = location;
-
-        if (currentLocation == null) {
-            Log.w(LOG_LABEL, "Using City Hall as default");
-            currentLocation = new Location("dummy");
-            currentLocation.setLatitude(39.954888);
-            currentLocation.setLongitude(-75.163206);
-        }
-        nearestDestinations = findNearestDestinations();
-
-        // set up carousel with nearest destinations
-        carouselView.setViewListener(new CarouselViewListener(this, true) {
-            @Override
-            public Destination getDestinationAt(int position) {
-                return nearestDestinations.get(position).getDestination();
-            }
-        });
-        carouselView.setPageCount(nearestDestinations.size());
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (requestCode == GpgLocationUtils.PERMISSION_REQUEST_ID) {
-            if (grantResults.length > 0) {
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    // TODO: re-request location
-                    Log.d(LOG_LABEL, "Re-requesting location");
-                    GpgLocationUtils.getLastKnownLocation(new WeakReference<>(this), this);
-                } else if (grantResults[0] == PackageManager.PERMISSION_DENIED) {
-                    GpgLocationUtils.displayPermissionRequestRationale(getApplicationContext());
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
@@ -55,7 +55,6 @@ public class HomeActivity extends BaseAttractionActivity {
             setUpCarousel();
         } else {
             Log.w(LOG_LABEL, "No nearest destinations yet in locationOrDestinationChanged");
-
         }
     }
 

--- a/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
@@ -1,4 +1,4 @@
-package com.gophillygo.app;
+package com.gophillygo.app.activities;
 
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
@@ -15,6 +15,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.GridView;
 
+import com.gophillygo.app.CarouselViewListener;
+import com.gophillygo.app.R;
+import com.gophillygo.app.activities.EventsListActivity;
+import com.gophillygo.app.activities.PlacesListActivity;
 import com.gophillygo.app.adapters.PlaceCategoryGridAdapter;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.Destination;

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -1,4 +1,4 @@
-package com.gophillygo.app;
+package com.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.arch.lifecycle.ViewModelProviders;
@@ -22,6 +22,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
+import com.gophillygo.app.CarouselViewListener;
+import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationInfo;

--- a/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
@@ -1,4 +1,4 @@
-package com.gophillygo.app;
+package com.gophillygo.app.activities;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModelProviders;
@@ -13,6 +13,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.PlacesListAdapter;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.AttractionInfo;

--- a/app/src/main/java/com/gophillygo/app/data/DestinationViewModel.java
+++ b/app/src/main/java/com/gophillygo/app/data/DestinationViewModel.java
@@ -6,6 +6,7 @@ import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.data.networkresource.Resource;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -28,7 +29,12 @@ public class DestinationViewModel extends AttractionViewModel {
         destinationRepository.updateDestination(destination);
     }
 
-    public void updateMultipleDestinations(List<Destination> destinations) {
+    public void updateMultipleDestinations(List<DestinationInfo> infos) {
+        List<Destination> destinations = new ArrayList<>(infos.size());
+        for (DestinationInfo info: infos) {
+            destinations.add(info.getDestination());
+        }
+        // update destinations all at once, so LiveData observer only triggers once
         destinationRepository.updateMultipleDestinations(destinations);
     }
 

--- a/app/src/main/java/com/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppComponent.java
@@ -19,6 +19,8 @@ import dagger.android.AndroidInjectionModule;
 @Component(modules = {
         AndroidInjectionModule.class,
         AppModule.class,
+
+        // Activities
         EventsListActivityModule.class,
         HomeActivityModule.class,
         PlaceDetailActivityModule.class,

--- a/app/src/main/java/com/gophillygo/app/di/AppModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppModule.java
@@ -28,6 +28,12 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 @Module(includes = ViewModelModule.class)
 class AppModule {
+
+    private final static String WEBSERVICE_URL = "https://gophillygo.org/";
+
+
+    // Data services
+
     @Singleton
     @Provides
     DestinationWebservice provideDestinationWebservice() {
@@ -44,7 +50,7 @@ class AppModule {
 
         return new Retrofit.Builder()
                 .client(client)
-                .baseUrl("https://gophillygo.org/")
+                .baseUrl(WEBSERVICE_URL)
                 .addConverterFactory(GsonConverterFactory.create())
                 .addCallAdapterFactory(new LiveDataCallAdapterFactory())
                 .build()

--- a/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
@@ -8,7 +8,6 @@ import dagger.android.ContributesAndroidInjector;
 
 @Module
 public abstract class EventsListActivityModule {
-    @SuppressWarnings("unused")
     @ContributesAndroidInjector
     abstract EventsListActivity contributeEventsListActivity();
 }

--- a/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/EventsListActivityModule.java
@@ -1,6 +1,6 @@
 package com.gophillygo.app.di;
 
-import com.gophillygo.app.EventsListActivity;
+import com.gophillygo.app.activities.EventsListActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;

--- a/app/src/main/java/com/gophillygo/app/di/HomeActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/HomeActivityModule.java
@@ -1,6 +1,6 @@
 package com.gophillygo.app.di;
 
-import com.gophillygo.app.HomeActivity;
+import com.gophillygo.app.activities.HomeActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;

--- a/app/src/main/java/com/gophillygo/app/di/HomeActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/HomeActivityModule.java
@@ -12,7 +12,6 @@ import dagger.android.ContributesAndroidInjector;
 
 @Module
 public abstract class HomeActivityModule {
-    @SuppressWarnings("unused")
     @ContributesAndroidInjector
     abstract HomeActivity contributeHomeActivity();
 }

--- a/app/src/main/java/com/gophillygo/app/di/PlaceDetailActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/PlaceDetailActivityModule.java
@@ -7,7 +7,6 @@ import dagger.android.ContributesAndroidInjector;
 
 @Module
 public abstract class PlaceDetailActivityModule {
-    @SuppressWarnings("unused")
     @ContributesAndroidInjector
     abstract PlaceDetailActivity contributePlaceDetailActivity();
 }

--- a/app/src/main/java/com/gophillygo/app/di/PlaceDetailActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/PlaceDetailActivityModule.java
@@ -1,6 +1,6 @@
 package com.gophillygo.app.di;
 
-import com.gophillygo.app.PlaceDetailActivity;
+import com.gophillygo.app.activities.PlaceDetailActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;

--- a/app/src/main/java/com/gophillygo/app/di/PlacesListActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/PlacesListActivityModule.java
@@ -1,6 +1,6 @@
 package com.gophillygo.app.di;
 
-import com.gophillygo.app.PlacesListActivity;
+import com.gophillygo.app.activities.PlacesListActivity;
 
 import dagger.Module;
 import dagger.android.ContributesAndroidInjector;

--- a/app/src/main/java/com/gophillygo/app/di/PlacesListActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/PlacesListActivityModule.java
@@ -7,7 +7,6 @@ import dagger.android.ContributesAndroidInjector;
 
 @Module
 public abstract class PlacesListActivityModule {
-    @SuppressWarnings("unused")
     @ContributesAndroidInjector
     abstract PlacesListActivity contributePlacesListActivity();
 }

--- a/app/src/main/java/com/gophillygo/app/di/ViewModelModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/ViewModelModule.java
@@ -17,7 +17,6 @@ import dagger.multibindings.IntoMap;
  * https://github.com/googlesamples/android-architecture-components/blob/e33782ba54ebe87f7e21e03542230695bc893818/GithubBrowserSample/app/src/main/java/com/android/example/github/di/ViewModelModule.java
  */
 
-@SuppressWarnings("unused")
 @Module
 public abstract class ViewModelModule {
     @Binds

--- a/app/src/main/java/com/gophillygo/app/utils/GpgLocationUtils.java
+++ b/app/src/main/java/com/gophillygo/app/utils/GpgLocationUtils.java
@@ -1,0 +1,114 @@
+package com.gophillygo.app.utils;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.support.v4.app.ActivityCompat;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationServices;
+import com.gophillygo.app.R;
+
+import java.lang.ref.WeakReference;
+
+
+public class GpgLocationUtils {
+
+    public interface LocationUpdateListener {
+        void locationFound(Location location);
+    }
+
+    // identifier for device location access request, if runtime prompt necessary
+    // request code must be in lower 8 bits
+    public static final int PERMISSION_REQUEST_ID = 11;
+    public static final int API_AVAILABILITY_REQUEST_ID = 22;
+
+    private static final String LOG_LABEL = "GpgLocationUtils";
+
+    // Do not instantiate
+    private GpgLocationUtils() {
+    }
+
+    /**
+     * Check if app has permission and access to device location, and that GPS is present and enabled.
+     * If so, start receiving location updates.
+     *
+     * @return True if location updates have been started
+     */
+    public static boolean getLastKnownLocation(WeakReference<Activity> caller, LocationUpdateListener listener) {
+        // check for location service availability and status
+
+        // if calling activity already gone, don't bother attempting to prompt for permissions now
+        Activity callingActivity = caller.get();
+        if (callingActivity == null) {
+            return false;
+        }
+
+        GoogleApiAvailability gapiAvailability = GoogleApiAvailability.getInstance();
+        int availability = gapiAvailability.isGooglePlayServicesAvailable(callingActivity);
+
+        if (availability != ConnectionResult.SUCCESS) {
+            WeakReference<Activity> activityWeakReference = new WeakReference<>(callingActivity);
+            // show system dialog to explain
+            showApiErrorDialog(activityWeakReference, gapiAvailability, availability);
+            return false;
+        }
+
+        // in API 23+, permission granting happens at runtime
+        if (ActivityCompat.checkSelfPermission(callingActivity,
+                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+
+            // in case user has denied location permissions to app previously, tell them why it's needed, then prompt again
+            if (ActivityCompat.shouldShowRequestPermissionRationale(callingActivity, Manifest.permission.ACCESS_FINE_LOCATION)) {
+                displayPermissionRequestRationale(callingActivity);
+                // On subsequent prompts, user will get a "never ask again" option in the dialog
+            }
+
+            ActivityCompat.requestPermissions(callingActivity, new String[]{
+                    Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSION_REQUEST_ID);
+            return false; // up to the activity to start this service again when permissions granted
+        } else {
+            // have correct permissions and Play services are available; go get location now
+            LocationRequest request = LocationRequest.create().setNumUpdates(12)
+                    .setExpirationDuration(10000)
+                    .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+            FusedLocationProviderClient client = LocationServices.getFusedLocationProviderClient(callingActivity);
+            client.requestLocationUpdates(request, null)
+                    .addOnCompleteListener(callingActivity, task -> {
+                        Log.d(LOG_LABEL, "Location request complete; go get last");
+                        client.getLastLocation().addOnCompleteListener(callingActivity, lastLocationTask -> {
+                            if (lastLocationTask.isSuccessful() && lastLocationTask.getResult() != null) {
+                                Log.d(LOG_LABEL, "Got result " + lastLocationTask.getResult());
+                                listener.locationFound(lastLocationTask.getResult());
+                            }
+                        });
+                    });
+            return true;
+        }
+    }
+
+    private static void showApiErrorDialog(WeakReference<Activity> caller, GoogleApiAvailability gapiAvailability, int errorCode) {
+        final Activity callingActivity = caller.get();
+        if (callingActivity == null) {
+            return;
+        }
+
+        Dialog errorDialog = gapiAvailability.getErrorDialog(callingActivity, errorCode, API_AVAILABILITY_REQUEST_ID);
+        errorDialog.show();
+    }
+
+    // Call this from activity in `onRequestPermissionsResult` if permission denied
+    public static void displayPermissionRequestRationale(Context context) {
+        Toast toast = Toast.makeText(context, context.getString(R.string.location_fine_permission_rationale), Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+}

--- a/app/src/main/res/layout/activity_events_list.xml
+++ b/app/src/main/res/layout/activity_events_list.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.gophillygo.app.EventsListActivity">
+    tools:context="com.gophillygo.app.activities.EventsListActivity">
 
 <RelativeLayout
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.gophillygo.app.HomeActivity">
+    tools:context="com.gophillygo.app.activities.HomeActivity">
 
     <com.synnapps.carouselview.CarouselView
         android:id="@+id/home_carousel"

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -3,12 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:fillViewport="true"
-    tools:context="com.gophillygo.app.PlaceDetailActivity">
+    tools:context="com.gophillygo.app.activities.PlaceDetailActivity">
     <data>
         <!-- set up data binding to destination -->
         <variable name="destination" type="com.gophillygo.app.data.models.Destination"/>
         <variable name="destinationInfo" type="com.gophillygo.app.data.models.DestinationInfo"/>
-        <variable name="activity" type="com.gophillygo.app.PlaceDetailActivity" />
+        <variable name="activity" type="com.gophillygo.app.activities.PlaceDetailActivity" />
         <!-- imports to allow referencing within data binding expressions -->
         <import type="android.view.View"/>
     </data>

--- a/app/src/main/res/layout/activity_places_list.xml
+++ b/app/src/main/res/layout/activity_places_list.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.gophillygo.app.PlacesListActivity">
+    tools:context="com.gophillygo.app.activities.PlacesListActivity">
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/custom_carousel_item.xml
+++ b/app/src/main/res/layout/custom_carousel_item.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context="com.gophillygo.app.HomeActivity">
+    tools:context="com.gophillygo.app.activities.HomeActivity">
     <data>
         <!-- set up data binding to destination -->
         <variable name="destination" type="com.gophillygo.app.data.models.Destination"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,5 +53,8 @@
 
     <!-- event list -->
     <string name="event_list_item_time_range">%s - %s</string>
+    <string name="location_requires_gps">Device does not have GPS, which is needed to get location. Please use a different device.</string>
+    <string name="location_gps_needed_rationale">GPS needs to be enabled to find destinations near you.</string>
+    <string name="location_fine_permission_rationale">Device location permission needed.</string>
     <string name="no_results">No results</string>
 </resources>

--- a/app/src/test/java/com/gophillygo/app/ExampleUnitTest.java
+++ b/app/src/test/java/com/gophillygo/app/ExampleUnitTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
     @Test
-    public void addition_isCorrect() throws Exception {
+    public void addition_isCorrect() {
         assertEquals(4, 2 + 2);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Overview

Request actual device location on app start and use it to find distances to destinations and order them to find the nearest destinations. Default to use City Hall if location cannot be obtained for some reason.

Also refactors activities to their own package, and moves the location request and data loading logic to `BaseAttractionActivity`. To do #41 later (if we want to start the app somewhere other than the home view), we can refactor other activities to use `BaseAttractionActivity`.


## Notes

Play services version 15, though recently released, does not seem to be supported yet for our compile version, which is why this uses Play services version 12.x instead (the last major version release).

Since the location requests here are short-lived and have an expiration time set, they're handled in static utility methods, rather than creating a service and/or using dependency injection to manage location components.

The fused location provider does not always return the latest; sending a new location to an emulator seems to only get picked up if the app is restarted (simply navigating between views continues to get the previous location from the provider). As we aren't providing navigation, this should be fine; continual location tracking isn't needed.


## Testing

 - If testing in emulator, use the "extended controls" to send a test location to the device (simulate GPS)
 - Newly installed app should ask for location permissions
 - If permissions denied, app should work, using City Hall as default location
 - If permissions accepted, carousel should refresh to show nearest places and new distances
 - Navigation between views should continue to work as expected (carousel still loads on return to home view)
 - Extra credit testing: if emulator/device is missing Play services or has outdated Play services version, app should show appropriate message about it and continue to function with default location

Closes #9.
