### PR TITLE
Implement filter toggle buttons on the place and events list activities

### DIFF
--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -3,6 +3,7 @@ package com.gophillygo.app.activities;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
@@ -13,6 +14,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.EventsListAdapter;
 import com.gophillygo.app.data.EventViewModel;
@@ -20,6 +22,8 @@ import com.gophillygo.app.data.models.AttractionInfo;
 import com.gophillygo.app.data.models.EventInfo;
 import com.gophillygo.app.data.networkresource.Resource;
 import com.gophillygo.app.data.networkresource.Status;
+import com.gophillygo.app.databinding.ActivityEventsListBinding;
+import com.gophillygo.app.databinding.FilterButtonBarBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 
 import java.util.ArrayList;
@@ -43,7 +47,7 @@ public class EventsListActivity extends FilterableListActivity
     EventViewModel viewModel;
 
     public EventsListActivity() {
-        super(R.layout.activity_events_list, R.id.events_list_toolbar, R.id.events_list_filter_button);
+        super(R.id.events_list_toolbar);
     }
 
     /**
@@ -88,6 +92,12 @@ public class EventsListActivity extends FilterableListActivity
                 data.removeObservers(this);
             }
         });
+    }
+
+    @Override
+    protected FilterButtonBarBinding setupDataBinding() {
+        ActivityEventsListBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_events_list);
+        return binding.eventsListFilterButtonBar;
     }
 
     @Override

--- a/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
@@ -3,12 +3,13 @@ package com.gophillygo.app.activities;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.widget.Button;
 
 import com.gophillygo.app.data.models.Filter;
+import com.gophillygo.app.databinding.FilterButtonBarBinding;
 import com.gophillygo.app.FilterDialog;
+import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 
 import cn.nekocode.badge.BadgeDrawable;
@@ -19,28 +20,31 @@ import cn.nekocode.badge.BadgeDrawable;
  */
 
 public abstract class FilterableListActivity extends BaseAttractionActivity
-        implements FilterDialog.FilterChangeListener {
+        implements FilterDialog.FilterChangeListener, ToolbarFilterListener {
 
-    private int layoutId, toolbarId, filterButtonId;
+    private int toolbarId;
 
     private Button filterButton;
     private Drawable filterIcon;
     private Toolbar toolbar;
 
     protected Filter filter;
+    private FilterButtonBarBinding filterBinding;
 
-    public FilterableListActivity(int layoutId, int toolbarId, int filterButtonId) {
-        this.layoutId = layoutId;
+    public FilterableListActivity(int toolbarId) {
         this.toolbarId = toolbarId;
-        this.filterButtonId = filterButtonId;
     }
 
     protected abstract void loadData();
+    protected abstract FilterButtonBarBinding setupDataBinding();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(layoutId);
+
+        filterBinding = setupDataBinding();
+        filterBinding.setListener(this);
+        filterBinding.setFilter(filter);
 
         // set up toolbar
         toolbar = findViewById(toolbarId);
@@ -52,9 +56,9 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
 
         // set up filter button
         filter = new Filter();
-        filterButton = findViewById(filterButtonId);
+        filterButton = findViewById(R.id.filter_bar_filter_button);
         filterButton.setOnClickListener(v -> {
-            FilterDialog filterDialog = FilterDialog.newInstance(filter);
+            FilterDialog filterDialog = FilterDialog.newInstance(new Filter(filter));
             filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
         });
     }
@@ -62,6 +66,8 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
     @Override
     public void filterChanged(Filter filter) {
         this.filter = filter;
+        filterBinding.setFilter(filter);
+        filterBinding.notifyPropertyChanged(BR.filter);
         loadData();
 
         int setFilterCount = filter.count();
@@ -80,4 +86,17 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
         }
 
     }
+
+    @Override
+    public void toggleLiked() {
+        filter.setLiked(filterBinding.filterBarLikedButton.isChecked());
+        filterChanged(filter);
+    }
+
+    @Override
+    public void toggleWantToGo() {
+        filter.setWantToGo(filterBinding.filterBarWantToGoButton.isChecked());
+        filterChanged(filter);
+    }
+
 }

--- a/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
@@ -58,6 +58,8 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
         filter = new Filter();
         filterButton = findViewById(R.id.filter_bar_filter_button);
         filterButton.setOnClickListener(v -> {
+            // Need to give the filter dialog a copy of the filter, or toggling the
+            // liked / want to go filters in the dialog will toggle the toolbar buttons too soon
             FilterDialog filterDialog = FilterDialog.newInstance(new Filter(filter));
             filterDialog.show(getSupportFragmentManager(), filterDialog.getTag());
         });

--- a/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
@@ -1,6 +1,7 @@
 package com.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
+import android.databinding.DataBindingUtil;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
@@ -14,6 +15,8 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
 import com.gophillygo.app.R;
+import com.gophillygo.app.databinding.ActivityMapsBinding;
+import com.gophillygo.app.databinding.FilterButtonBarBinding;
 import com.gophillygo.app.utils.GpgLocationUtils;
 
 import java.lang.ref.WeakReference;
@@ -27,17 +30,23 @@ public class MapsActivity extends FilterableListActivity implements OnMapReadyCa
     private Toolbar toolbar;
 
     public MapsActivity() {
-        this(R.layout.activity_maps, R.id.map_toolbar, R.id.filter_bar_filter_button);
+        this(R.id.map_toolbar);
     }
 
-    public MapsActivity(int layoutId, int toolbarId, int filterButtonId) {
-        super(layoutId, toolbarId, filterButtonId);
+    public MapsActivity(int toolbarId) {
+        super(toolbarId);
     }
 
+    @Override
+    protected FilterButtonBarBinding setupDataBinding() {
+        // TODO: #11 load destination markers
+        ActivityMapsBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_maps);
+        return binding.mapFilterButtonBar;
+    }
 
     @Override
     protected void loadData() {
-        // TODO: #11 load destionation markers
+        // TODO: #11 load destination markers
         Log.d(LOG_LABEL, "load data in maps activity");
     }
 

--- a/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
@@ -3,6 +3,7 @@ package com.gophillygo.app.activities;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
@@ -13,6 +14,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.PlacesListAdapter;
 import com.gophillygo.app.data.DestinationViewModel;
@@ -20,6 +22,8 @@ import com.gophillygo.app.data.models.AttractionInfo;
 import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.data.networkresource.Resource;
 import com.gophillygo.app.data.networkresource.Status;
+import com.gophillygo.app.databinding.ActivityPlacesListBinding;
+import com.gophillygo.app.databinding.FilterButtonBarBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 
 import java.util.ArrayList;
@@ -44,7 +48,7 @@ public class PlacesListActivity extends FilterableListActivity implements
     DestinationViewModel viewModel;
 
     public PlacesListActivity() {
-        super(R.layout.activity_places_list, R.id.places_list_toolbar, R.id.filter_bar_filter_button);
+        super(R.id.places_list_toolbar);
     }
 
     /**
@@ -87,6 +91,12 @@ public class PlacesListActivity extends FilterableListActivity implements
                 data.removeObservers(this);
             }
         });
+    }
+
+    @Override
+    protected FilterButtonBarBinding setupDataBinding() {
+        ActivityPlacesListBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_places_list);
+        return binding.placesListFilterButtonBar;
     }
 
     @Override

--- a/app/src/main/java/com/gophillygo/app/activities/ToolbarFilterListener.java
+++ b/app/src/main/java/com/gophillygo/app/activities/ToolbarFilterListener.java
@@ -1,0 +1,6 @@
+package com.gophillygo.app.activities;
+
+public interface ToolbarFilterListener {
+    void toggleLiked();
+    void toggleWantToGo();
+}

--- a/app/src/main/java/com/gophillygo/app/data/models/Filter.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Filter.java
@@ -35,6 +35,10 @@ public class Filter extends BaseObservable implements Serializable {
         this(false, false, false, false, false, false, false, false);
     }
 
+    public Filter(Filter other) {
+        this(other.nature, other.exercise, other.educational, other.been, other.wantToGo, other.notInterested, other.liked, other.accessible);
+    }
+
     public Filter(boolean nature, boolean exercise, boolean educational, boolean been,
                   boolean wantToGo, boolean notInterested, boolean liked, boolean accessible) {
         this.nature = nature;

--- a/app/src/main/java/com/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppComponent.java
@@ -3,7 +3,6 @@ package com.gophillygo.app.di;
 import android.app.Application;
 
 import com.gophillygo.app.GoPhillyGoApp;
-import com.gophillygo.app.activities.MapsActivity;
 
 import javax.inject.Singleton;
 

--- a/app/src/main/res/layout/activity_events_list.xml
+++ b/app/src/main/res/layout/activity_events_list.xml
@@ -43,7 +43,7 @@
                 android:layout_height="match_parent"
                 android:gravity="center"
                 android:visibility="gone"
-                android:text="@string/no_results" />
+                android:text="@string/filter_no_results" />
 
         </RelativeLayout>
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_events_list.xml
+++ b/app/src/main/res/layout/activity_events_list.xml
@@ -1,78 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context="com.gophillygo.app.activities.EventsListActivity">
-
-<RelativeLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/events_list_toolbar"
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:fitsSystemWindows="true"
-        android:elevation="0dp"
-        android:background="@color/color_primary"
-        app:title="@string/events_list_title"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-        tools:targetApi="lollipop" />
+        android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/events_list_filter_button_bar"
-        android:layout_below="@+id/events_list_toolbar"
-        android:background="@color/color_primary"
-        android:paddingStart="6dp"
-        android:paddingEnd="6dp"
-        android:weightSum="3"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <android.support.v7.widget.AppCompatButton
-            android:id="@+id/events_list_filter_button"
-            android:textColor="@color/color_white"
-            android:layout_gravity="start"
-            android:layout_weight="1"
-            android:background="@drawable/toggle_button_toolbar_unchecked"
-            android:drawableStart="@drawable/ic_filter_list_white_24px"
-            style="@style/FilterBarButton"
-            android:text="@string/filter_button_title" />
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/events_list_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:fitsSystemWindows="true"
+                android:elevation="0dp"
+                android:background="@color/color_primary"
+                app:title="@string/events_list_title"
+                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                tools:targetApi="lollipop" />
 
-        <Space
-            android:layout_weight="1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            <include layout="@layout/filter_button_bar"
+                android:id="@+id/events_list_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/events_list_toolbar" />
 
-        <com.gophillygo.app.GpgToolbarToggleButton
-            android:id="@+id/events_list_want_to_go_filter_button"
-            android:text="@string/place_want_to_go_option"
-            android:layout_weight="1"
-            android:drawableStart="@drawable/toggle_button_toolbar_flag_drawable_selector"
-            style="@style/FilterBarButton"
-            android:textColor="@drawable/toggle_button_toolbar_text_selector"
-            android:layout_gravity="end" />
-    </LinearLayout>
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/events_list_recycler_view"
+                android:layout_below="@id/events_list_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+            </android.support.v7.widget.RecyclerView>
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/events_list_recycler_view"
-        android:layout_below="@id/events_list_filter_button_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-    </android.support.v7.widget.RecyclerView>
+            <TextView
+                android:id="@+id/empty_events_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:visibility="gone"
+                android:text="@string/no_results" />
 
-    <TextView
-        android:id="@+id/empty_events_list"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:visibility="gone"
-        android:text="@string/no_results" />
-
-</RelativeLayout>
-</android.support.design.widget.CoordinatorLayout>
+        </RelativeLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -1,42 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/map_activity"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context=".activities.MapsActivity">
-
-    <RelativeLayout
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/map_activity"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/map_toolbar"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:fitsSystemWindows="true"
-            android:elevation="0dp"
-            android:background="@color/color_primary"
-            app:title="@string/title_activity_maps"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            tools:targetApi="lollipop" />
+            android:layout_height="match_parent">
 
-        <include layout="@layout/filter_button_bar"
-            android:id="@+id/map_filter_button_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/map_toolbar" />
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/map_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:fitsSystemWindows="true"
+                android:elevation="0dp"
+                android:background="@color/color_primary"
+                app:title="@string/title_activity_maps"
+                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                tools:targetApi="lollipop" />
 
-        <fragment
-            android:id="@+id/map"
-            android:name="com.google.android.gms.maps.SupportMapFragment"
-            android:layout_below="@+id/map_filter_button_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            <include layout="@layout/filter_button_bar"
+                android:id="@+id/map_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/map_toolbar" />
 
-    </RelativeLayout>
-</android.support.design.widget.CoordinatorLayout>
+            <fragment
+                android:id="@+id/map"
+                android:name="com.google.android.gms.maps.SupportMapFragment"
+                android:layout_below="@+id/map_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </RelativeLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -2,7 +2,6 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:fillViewport="true"
     tools:context="com.gophillygo.app.activities.PlaceDetailActivity">
     <data>
         <!-- set up data binding to destination -->
@@ -13,7 +12,7 @@
         <import type="android.view.View"/>
     </data>
     <ScrollView
-
+        android:fillViewport="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_places_list.xml
+++ b/app/src/main/res/layout/activity_places_list.xml
@@ -1,47 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context="com.gophillygo.app.activities.PlacesListActivity">
-    <RelativeLayout
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/places_list_toolbar"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:fitsSystemWindows="true"
-            android:elevation="0dp"
-            android:background="@color/color_primary"
-            app:title="@string/places_list_title"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            tools:targetApi="lollipop" />
+            android:layout_height="match_parent">
 
-        <include layout="@layout/filter_button_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/places_list_toolbar" />
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/places_list_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:fitsSystemWindows="true"
+                android:elevation="0dp"
+                android:background="@color/color_primary"
+                app:title="@string/places_list_title"
+                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                tools:targetApi="lollipop" />
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/places_list_recycler_view"
-            android:layout_below="@id/filter_button_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-        </android.support.v7.widget.RecyclerView>
+            <include layout="@layout/filter_button_bar"
+                android:id="@+id/places_list_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/places_list_toolbar" />
 
-        <TextView
-            android:id="@+id/empty_places_list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:visibility="gone"
-            android:text="@string/no_results" />
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/places_list_recycler_view"
+                android:layout_below="@id/places_list_filter_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+            </android.support.v7.widget.RecyclerView>
 
-    </RelativeLayout>
-</android.support.design.widget.CoordinatorLayout>
+            <TextView
+                android:id="@+id/empty_places_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:visibility="gone"
+                android:text="@string/no_results" />
+
+        </RelativeLayout>
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/activity_places_list.xml
+++ b/app/src/main/res/layout/activity_places_list.xml
@@ -42,7 +42,7 @@
                 android:layout_height="match_parent"
                 android:gravity="center"
                 android:visibility="gone"
-                android:text="@string/no_results" />
+                android:text="@string/filter_no_results" />
 
         </RelativeLayout>
     </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/filter_button_bar.xml
+++ b/app/src/main/res/layout/filter_button_bar.xml
@@ -1,45 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable name="filter" type="com.gophillygo.app.data.models.Filter" />
+        <variable name="listener" type="com.gophillygo.app.activities.ToolbarFilterListener" />
+    </data>
+    <LinearLayout
+        android:id="@+id/filter_button_bar"
+        android:background="@color/color_primary"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        android:weightSum="4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/filter_button_bar"
-    android:background="@color/color_primary"
-    android:paddingStart="6dp"
-    android:paddingEnd="6dp"
-    android:weightSum="4"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+        <android.support.v7.widget.AppCompatButton
+            android:id="@+id/filter_bar_filter_button"
+            android:textColor="@color/color_white"
+            android:layout_gravity="start"
+            android:layout_weight="1"
+            android:background="@drawable/toggle_button_toolbar_unchecked"
+            android:drawableStart="@drawable/ic_filter_list_white_24px"
+            style="@style/FilterBarButton"
+            android:text="@string/filter_button_title" />
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/filter_bar_filter_button"
-        android:textColor="@color/color_white"
-        android:layout_gravity="start"
-        android:layout_weight="1"
-        android:background="@drawable/toggle_button_toolbar_unchecked"
-        android:drawableStart="@drawable/ic_filter_list_white_24px"
-        style="@style/FilterBarButton"
-        android:text="@string/filter_button_title" />
+        <Space
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
 
-    <Space
-        android:layout_weight="1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        <com.gophillygo.app.GpgToolbarToggleButton
+            android:id="@+id/filter_bar_liked_button"
+            style="@style/FilterBarButton"
+            android:checked="@{filter.liked}"
+            android:onClick="@{view -> listener.toggleLiked()}"
+            android:textColor="@drawable/toggle_button_toolbar_text_selector"
+            android:layout_gravity="end"
+            android:layout_weight="1"
+            android:drawableStart="@drawable/toggle_button_toolbar_like_drawable_selector"
+            android:text="@string/place_liked_option" />
 
-    <com.gophillygo.app.GpgToolbarToggleButton
-        android:id="@+id/filter_bar_liked_button"
-        style="@style/FilterBarButton"
-        android:textColor="@drawable/toggle_button_toolbar_text_selector"
-        android:layout_gravity="end"
-        android:layout_weight="1"
-        android:drawableStart="@drawable/toggle_button_toolbar_like_drawable_selector"
-        android:text="@string/place_liked_option" />
-
-    <com.gophillygo.app.GpgToolbarToggleButton
-        android:id="@+id/filter_bar_want_to_go_button"
-        android:text="@string/place_want_to_go_option"
-        android:layout_weight="1"
-        android:drawableStart="@drawable/toggle_button_toolbar_flag_drawable_selector"
-        style="@style/FilterBarButton"
-        android:textColor="@drawable/toggle_button_toolbar_text_selector"
-        android:layout_gravity="end" />
-</LinearLayout>
+        <com.gophillygo.app.GpgToolbarToggleButton
+            android:id="@+id/filter_bar_want_to_go_button"
+            android:checked="@{filter.wantToGo}"
+            android:onClick="@{view -> listener.toggleWantToGo()}"
+            android:text="@string/place_want_to_go_option"
+            android:layout_weight="1"
+            android:drawableStart="@drawable/toggle_button_toolbar_flag_drawable_selector"
+            style="@style/FilterBarButton"
+            android:textColor="@drawable/toggle_button_toolbar_text_selector"
+            android:layout_gravity="end" />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="location_requires_gps">Device does not have GPS, which is needed to get location. Please use a different device.</string>
     <string name="location_gps_needed_rationale">GPS needs to be enabled to find destinations near you.</string>
     <string name="location_fine_permission_rationale">Device location permission needed.</string>
-    <string name="no_results">No results</string>
+    <string name="filter_no_results">No results</string>
     <string name="title_activity_maps">Map</string>
 
     <!-- map -->


### PR DESCRIPTION
## Overview

Implements filtering using the shortcut buttons on the event and place detail lists.

## Screenshot
![screenshot_20180504-143109](https://user-images.githubusercontent.com/4432106/39646119-6e976648-4fa8-11e8-9231-bcea1bf8717f.png)
![screenshot_20180504-143115](https://user-images.githubusercontent.com/4432106/39646120-6ea4dab2-4fa8-11e8-940e-6296da1b8e9a.png)
![screenshot_20180504-143122](https://user-images.githubusercontent.com/4432106/39646121-6eb1d2f8-4fa8-11e8-9807-04e4d59b009a.png)



## Notes

At @lederer's request I changed the events list to include a "Liked" filter button, like the places list.
This lets all the views (events, places, and map) to share the same filter button logic in `FilterableListActivity` 😃 

Closes #40 