### PR TITLE
Add event detail activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,13 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.gophillygo.app.activities.HomeActivity" />
         </activity>
+        <activity
+            android:name=".activities.EventDetailActivity"
+            android:parentActivityName=".activities.EventsListActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.gophillygo.app.activities.EventsListActivity" />
+        </activity>
         <!--
              The API key for Google Maps-based APIs is defined as a string resource.
              (See the file "res/values/google_maps_api.xml").

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -1,0 +1,91 @@
+package com.gophillygo.app.activities;
+
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
+import android.view.View;
+import android.widget.TextView;
+
+import com.gophillygo.app.R;
+import com.gophillygo.app.data.models.AttractionInfo;
+import com.gophillygo.app.data.models.DestinationInfo;
+
+abstract class AttractionDetailActivity extends AppCompatActivity {
+    protected static final int COLLAPSED_LINE_COUNT = 4;
+    protected static final int EXPANDED_MAX_LINES = 50;
+    protected DestinationInfo destinationInfo;
+
+    protected View.OnClickListener toggleClickListener;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        toggleClickListener = v -> {
+            // click handler for toggling expanding/collapsing description card
+            TextView descriptionView = findViewById(R.id.detail_description_text);
+
+            TextView view = (TextView) v;
+            int current = descriptionView.getMaxLines();
+            if (current == COLLAPSED_LINE_COUNT) {
+                descriptionView.setMaxLines(EXPANDED_MAX_LINES);
+                // make links clickable in expanded view
+                descriptionView.setMovementMethod(LinkMovementMethod.getInstance());
+                view.setText(R.string.detail_description_collapse);
+            } else {
+                descriptionView.setMaxLines(COLLAPSED_LINE_COUNT);
+                descriptionView.setEllipsize(TextUtils.TruncateAt.END);
+                // disable clicking links to also disable scrolling
+                descriptionView.setMovementMethod(null);
+                // must reset click listener after unsetting movement method
+                descriptionView.setOnClickListener(toggleClickListener);
+                // set text again, to make ellipsize run
+                descriptionView.setText(descriptionView.getText());
+                view.setText(R.string.detail_description_expand);
+            }
+        };
+    }
+
+    // open map when user clicks map button
+    public void goToMap(View view) {
+        // TODO: #10 open within app map view, once implemented
+        // for now, open Google Maps externally with a marker at the given location
+        String locationString = destinationInfo.getDestination().getLocation().toString();
+        Uri gmapsUri = Uri.parse("geo:" + locationString + "?q=" + locationString + "(" +
+                destinationInfo.getDestination().getName() + ")");
+        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmapsUri);
+        mapIntent.setPackage("com.google.android.apps.maps");
+        if (mapIntent.resolveActivity(getPackageManager()) != null) {
+            startActivity(mapIntent);
+        }
+    }
+
+    // open the GoPhillyGo website, passing the destination, when "get directions" clicked
+    public void goToDirections(View view) {
+        // pass parameters destination and destinationText to https://gophillygo.org/
+        Uri directionsUri = new Uri.Builder().scheme("https").authority("gophillygo.org")
+                // TODO: #9 send current user location as origin
+                .appendQueryParameter("origin", "")
+                .appendQueryParameter("originText", "")
+                .appendQueryParameter("destination", destinationInfo.getDestination().getLocation().toString())
+                .appendQueryParameter("destinationText", destinationInfo.getDestination().getAddress()).build();
+        Intent intent = new Intent(Intent.ACTION_VIEW, directionsUri);
+        startActivity(intent);
+    }
+
+    // open website for destination in browser
+    public void goToWebsite(View view) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(destinationInfo.getDestination().getWebsiteUrl()));
+        startActivity(intent);
+    }
+
+    public Drawable getFlagImage(AttractionInfo attractionInfo) {
+        if (attractionInfo == null) return null;
+
+        return ContextCompat.getDrawable(this, attractionInfo.getFlagImage());
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -1,0 +1,177 @@
+package com.gophillygo.app.activities;
+
+import android.annotation.SuppressLint;
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Intent;
+import android.databinding.DataBindingUtil;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v7.view.menu.MenuBuilder;
+import android.support.v7.view.menu.MenuPopupHelper;
+import android.support.v7.widget.CardView;
+import android.support.v7.widget.PopupMenu;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.TextView;
+
+import com.gophillygo.app.R;
+import com.gophillygo.app.data.DestinationViewModel;
+import com.gophillygo.app.data.EventViewModel;
+import com.gophillygo.app.data.models.DestinationInfo;
+import com.gophillygo.app.data.models.Event;
+import com.gophillygo.app.data.models.EventInfo;
+import com.gophillygo.app.databinding.ActivityEventDetailBinding;
+import com.gophillygo.app.di.GpgViewModelFactory;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+public class EventDetailActivity extends AttractionDetailActivity {
+
+    public static final String EVENT_ID_KEY = "eventId";
+    private static final String LOG_LABEL = "EventDetail";
+
+    private static final DateFormat timeFormat, monthDayFormat;
+
+    static {
+        timeFormat = new SimpleDateFormat("h:mm a", Locale.US);
+        monthDayFormat = new SimpleDateFormat("E MMM dd", Locale.US);
+    }
+
+    private long eventId = -1;
+    private EventInfo eventInfo;
+
+    private ActivityEventDetailBinding binding;
+
+    @SuppressWarnings("WeakerAccess")
+    @Inject
+    GpgViewModelFactory viewModelFactory;
+    @SuppressWarnings("WeakerAccess")
+    EventViewModel viewModel;
+    @SuppressWarnings("WeakerAccess")
+    DestinationViewModel destinationViewModel;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_event_detail);
+        binding.setActivity(this);
+
+        Toolbar toolbar = findViewById(R.id.event_detail_toolbar);
+        // disable default app name title display
+        toolbar.setTitle("");
+        setSupportActionBar(toolbar);
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        if (getIntent().hasExtra(EVENT_ID_KEY)) {
+            eventId = getIntent().getLongExtra(EVENT_ID_KEY, -1);
+        }
+
+        if (eventId == -1) {
+            Log.e(LOG_LABEL, "Event not found when attempting to load detail view.");
+            finish();
+        }
+
+        viewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
+        destinationViewModel = ViewModelProviders.of(this, viewModelFactory).get(DestinationViewModel.class);
+        viewModel.getEvent(eventId).observe(this, eventInfo -> {
+            // TODO: handle if event not found (go to list of events?)
+            if (eventInfo == null || eventInfo.getEvent() == null) {
+                Log.e(LOG_LABEL, "No matching event found for ID " + eventId);
+                return;
+            }
+
+            this.eventInfo = eventInfo;
+            Integer destinationId = eventInfo.getEvent().getDestination();
+            if (destinationId != null) {
+                LiveData<DestinationInfo> data = destinationViewModel.getDestination(destinationId);
+                data.observe(this, destinationInfo -> {
+                    this.destinationInfo = destinationInfo;
+                    if (destinationInfo != null) {
+                        binding.setDestination(destinationInfo.getDestination());
+                    } else {
+                        Log.e(LOG_LABEL, "No matching destination found for ID " + destinationId);
+                    }
+                    // Since we call `getDestination(...).observe(...)` every time the event is updated,
+                    // we need to remove destination observer every time it is called
+                    data.removeObservers(this);
+                });
+            }
+            // set up data binding object
+            binding.setEvent(eventInfo.getEvent());
+            binding.setEventInfo(eventInfo);
+            displayEvent();
+        });
+    }
+
+    @Override
+    // open website for event in browser
+    public void goToWebsite(View view) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(eventInfo.getEvent().getWebsiteUrl()));
+        startActivity(intent);
+    }
+
+    // add event in calendar app
+    public void addToCalendar(View view) {
+        // TODO #21: open calendar with intent
+    }
+
+    @SuppressLint({"RestrictedApi", "RtlHardcoded"})
+    private void displayEvent() {
+        TextView descriptionToggle = findViewById(R.id.detail_description_toggle);
+        descriptionToggle.setOnClickListener(toggleClickListener);
+
+        // show popover for flag options (been, want to go, etc.)
+        CardView flagOptionsCard = findViewById(R.id.event_detail_flag_options_card);
+        flagOptionsCard.setOnClickListener(v -> {
+            Log.d(LOG_LABEL, "Clicked flags button");
+            PopupMenu menu = new PopupMenu(this, flagOptionsCard);
+            menu.getMenuInflater().inflate(R.menu.place_options_menu, menu.getMenu());
+            menu.setOnMenuItemClickListener(item -> {
+                eventInfo.updateAttractionFlag(item.getItemId());
+                viewModel.updateAttractionFlag(eventInfo.getFlag());
+
+                return true;
+            });
+
+            // Force icons to show in the popup menu via the support library API
+            // https://stackoverflow.com/questions/6805756/is-it-possible-to-display-icons-in-a-popupmenu
+            MenuPopupHelper popupHelper = new MenuPopupHelper(this,
+                    (MenuBuilder)menu.getMenu(),
+                    flagOptionsCard);
+            popupHelper.setForceShowIcon(true);
+            popupHelper.setGravity(Gravity.END|Gravity.RIGHT);
+            popupHelper.show();
+        });
+    }
+
+    public String getEventTimeString() {
+        Event event = eventInfo.getEvent();
+        Date start = event.getStart();
+        Date end = event.getEnd();
+
+        if (start == null || end == null) {
+            return "";
+        }
+
+        if (event.isSingleDayEvent()) {
+            return getString(R.string.event_detail_single_day_time_range,
+                    monthDayFormat.format(start),
+                    timeFormat.format(start),
+                    timeFormat.format(end));
+        } else {
+            // multi-day event
+            return getString(R.string.event_list_item_time_range,
+                    monthDayFormat.format(start),
+                    monthDayFormat.format(end));
+        }
+    }
+}

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -7,15 +7,18 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.CalendarContract;
 import android.support.v7.view.menu.MenuBuilder;
 import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
+import android.text.Html;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
@@ -121,7 +124,19 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
     // add event in calendar app
     public void addToCalendar(View view) {
-        // TODO #21: open calendar with intent
+        Event event = eventInfo.getEvent();
+        Intent intent = new Intent(Intent.ACTION_INSERT)
+                .setData(CalendarContract.Events.CONTENT_URI)
+                .putExtra(CalendarContract.Events.TITLE, event.getName())
+                .putExtra(CalendarContract.Events.DESCRIPTION, event.getDescription())
+                .putExtra(CalendarContract.Events.EVENT_LOCATION, eventInfo.getDestinationName())
+                .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, event.getStart().getTime())
+                .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, event.getEnd().getTime());
+        if (intent.resolveActivity(getPackageManager()) != null) {
+            startActivity(intent);
+        } else {
+            Toast.makeText(this, R.string.event_detail_no_calendar, Toast.LENGTH_SHORT).show();
+        }
     }
 
     @SuppressLint({"RestrictedApi", "RtlHardcoded"})

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
-import android.text.Html;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -142,7 +141,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
         Intent intent = new Intent(Intent.ACTION_INSERT)
                 .setData(CalendarContract.Events.CONTENT_URI)
                 .putExtra(CalendarContract.Events.TITLE, event.getName())
-                .putExtra(CalendarContract.Events.DESCRIPTION, event.getDescription())
+                .putExtra(CalendarContract.Events.DESCRIPTION, event.getHtmlDescription().toString())
                 .putExtra(CalendarContract.Events.EVENT_LOCATION, eventInfo.getDestinationName())
                 .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startTime)
                 .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endTime)

--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -51,7 +51,6 @@ public class EventsListActivity extends FilterableListActivity
     }
 
     /**
-     * TODO: #20
      * Go to event detail view when an event in the list clicked.
      *
      * @param position Offset of the position of the list item clicked
@@ -60,11 +59,9 @@ public class EventsListActivity extends FilterableListActivity
         // Get database ID for event clicked, based on positional offset, and pass it along
         long eventId = eventsListView.getAdapter().getItemId(position);
         Log.d(LOG_LABEL, "Clicked event with ID: " + eventId);
-        /*
         Intent intent = new Intent(this, EventDetailActivity.class);
         intent.putExtra(EventDetailActivity.EVENT_ID_KEY, eventId);
         startActivity(intent);
-        */
     }
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -2,29 +2,19 @@ package com.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.arch.lifecycle.ViewModelProviders;
-import android.content.Intent;
 import android.databinding.DataBindingUtil;
-import android.graphics.drawable.Drawable;
-import android.net.Uri;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
-import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.LayoutInflater;
-import android.view.View;
 import android.widget.TextView;
 
 import com.gophillygo.app.CarouselViewListener;
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.Destination;
-import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.databinding.ActivityPlaceDetailBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 import com.gophillygo.app.utils.FlagMenuUtils;
@@ -32,23 +22,16 @@ import com.synnapps.carouselview.CarouselView;
 
 import javax.inject.Inject;
 
-public class PlaceDetailActivity extends AppCompatActivity {
+public class PlaceDetailActivity extends AttractionDetailActivity {
 
     public static final String DESTINATION_ID_KEY = "placeId";
     private static final String LOG_LABEL = "PlaceDetail";
 
-    private static final int COLLAPSED_LINE_COUNT = 4;
-    private static final int EXPANDED_MAX_LINES = 50;
-
     private long placeId = -1;
-    private DestinationInfo destinationInfo;
 
-    private LayoutInflater inflater;
     private ActivityPlaceDetailBinding binding;
     private CarouselView carouselView;
     private Toolbar toolbar;
-    TextView descriptionView;
-    private View.OnClickListener toggleClickListener;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
@@ -62,7 +45,6 @@ public class PlaceDetailActivity extends AppCompatActivity {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_place_detail);
         binding.setActivity(this);
 
-        inflater = getLayoutInflater();
         toolbar = findViewById(R.id.place_detail_toolbar);
         // disable default app name title display
         toolbar.setTitle("");
@@ -99,68 +81,6 @@ public class PlaceDetailActivity extends AppCompatActivity {
             binding.setDestinationInfo(destinationInfo);
             displayDestination();
         });
-
-        // click handler for toggling expanding/collapsing description card
-        descriptionView = findViewById(R.id.place_detail_description_text);
-        toggleClickListener = v -> {
-            TextView view = (TextView) v;
-            int current = descriptionView.getMaxLines();
-            if (current == COLLAPSED_LINE_COUNT) {
-                descriptionView.setMaxLines(EXPANDED_MAX_LINES);
-                // make links clickable in expanded view
-                descriptionView.setMovementMethod(LinkMovementMethod.getInstance());
-                view.setText(R.string.place_detail_description_collapse);
-            } else {
-                descriptionView.setMaxLines(COLLAPSED_LINE_COUNT);
-                descriptionView.setEllipsize(TextUtils.TruncateAt.END);
-                // disable clicking links to also disable scrolling
-                descriptionView.setMovementMethod(null);
-                // must reset click listener after unsetting movement method
-                descriptionView.setOnClickListener(toggleClickListener);
-                // set text again, to make ellipsize run
-                descriptionView.setText(descriptionView.getText());
-                view.setText(R.string.place_detail_description_expand);
-            }
-        };
-    }
-
-    // open map when user clicks map button
-    public void goToMap(View view) {
-        // TODO: #10 open within app map view, once implemented
-        // for now, open Google Maps externally with a marker at the given location
-        String locationString = destinationInfo.getDestination().getLocation().toString();
-        Uri gmapsUri = Uri.parse("geo:" + locationString + "?q=" + locationString + "(" +
-                destinationInfo.getDestination().getName() + ")");
-        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmapsUri);
-        mapIntent.setPackage("com.google.android.apps.maps");
-        if (mapIntent.resolveActivity(getPackageManager()) != null) {
-            startActivity(mapIntent);
-        }
-    }
-
-    // open the GoPhillyGo website, passing the destination, when "get directions" clicked
-    public void goToDirections(View view) {
-        // pass parameters destination and destinationText to https://gophillygo.org/
-        Uri directionsUri = new Uri.Builder().scheme("https").authority("gophillygo.org")
-                // TODO: #9 send current user location as origin
-                .appendQueryParameter("origin", "")
-                .appendQueryParameter("originText", "")
-                .appendQueryParameter("destination", destinationInfo.getDestination().getLocation().toString())
-                .appendQueryParameter("destinationText", destinationInfo.getDestination().getAddress()).build();
-        Intent intent = new Intent(Intent.ACTION_VIEW, directionsUri);
-        startActivity(intent);
-    }
-
-    // open website for destination in browser
-    public void goToWebsite(View view) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(destinationInfo.getDestination().getWebsiteUrl()));
-        startActivity(intent);
-    }
-
-    public Drawable getFlagImage(DestinationInfo attractionInfo) {
-        if (attractionInfo == null) return null;
-
-        return ContextCompat.getDrawable(this, attractionInfo.getFlagImage());
     }
 
     @SuppressLint({"RestrictedApi", "RtlHardcoded"})
@@ -174,6 +94,9 @@ public class PlaceDetailActivity extends AppCompatActivity {
         });
         carouselView.setPageCount(1);
 
+        TextView descriptionToggle = findViewById(R.id.detail_description_toggle);
+        descriptionToggle.setOnClickListener(toggleClickListener);
+
         // set count of upcoming events
         int eventCount = destinationInfo.getEventCount();
         TextView upcomingEventsView = findViewById(R.id.place_detail_upcoming_events);
@@ -184,10 +107,6 @@ public class PlaceDetailActivity extends AppCompatActivity {
         // TODO: #18 go to filtered event list with events for destination on click
         upcomingEventsView.setOnClickListener(v -> Log.d(LOG_LABEL,
                 "Clicked upcoming events for destination " +  destinationInfo.getDestination().getName()));
-
-
-        TextView descriptionToggle = findViewById(R.id.place_detail_description_toggle);
-        descriptionToggle.setOnClickListener(toggleClickListener);
 
         // show popover for flag options (been, want to go, etc.)
         CardView flagOptionsCard = findViewById(R.id.place_detail_flag_options_card);

--- a/app/src/main/java/com/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/com/gophillygo/app/data/EventDao.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Dao
 public abstract class EventDao implements AttractionDao<Event> {
-    @Query("SELECT event.*, destination.name AS destinationName, " +
+    @Query("SELECT event.*, destination.name AS destinationName, NULL AS distance, " +
             "destination.categories AS destinationCategories, attractionflag.option " +
             "FROM event " +
             "LEFT JOIN destination ON destination.id = event.destination " +
@@ -26,7 +26,7 @@ public abstract class EventDao implements AttractionDao<Event> {
             "ORDER BY event.start_date ASC;")
     public abstract LiveData<List<EventInfo>> getAll();
 
-    @Query("SELECT event.*, destination.name AS destinationName, " +
+    @Query("SELECT event.*, destination.name AS destinationName, destination.distance AS distance, " +
             "destination.categories AS destinationCategories, attractionflag.option " +
             "FROM event " +
             "LEFT JOIN destination ON destination.id = event.destination " +

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -38,7 +38,7 @@ public class Event extends Attraction {
 
     // using Integer instead of int so it may be nullable
     @ColumnInfo(index = true)
-    private final Integer destination;
+    private Integer destination;
 
     @ColumnInfo(name = "start_date", index = true)
     @SerializedName("start_date")
@@ -86,6 +86,10 @@ public class Event extends Attraction {
 
     public Integer getDestination() {
         return destination;
+    }
+
+    public void setDestination(Integer id) {
+        destination = id;
     }
 
     public String getStartDate() {

--- a/app/src/main/java/com/gophillygo/app/data/models/EventInfo.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/EventInfo.java
@@ -11,13 +11,15 @@ public class EventInfo extends AttractionInfo<Event> {
     // fetch fields of related destination from database into these properties
     private final String destinationName;
     private final ArrayList<String> destinationCategories;
+    private Float distance;
 
     public EventInfo(Event event, String destinationName, ArrayList<String> destinationCategories,
-                     AttractionFlag.Option option) {
+                     AttractionFlag.Option option, Float distance) {
         super(event, option);
         this.event = event;
         this.destinationName = destinationName;
         this.destinationCategories = destinationCategories;
+        this.distance = distance;
     }
 
     @Override
@@ -39,5 +41,9 @@ public class EventInfo extends AttractionInfo<Event> {
 
     public ArrayList<String> getDestinationCategories() {
         return destinationCategories;
+    }
+
+    public Float getDistance() {
+        return distance;
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -48,13 +48,20 @@ abstract public class AttractionNetworkBoundResource<A extends Attraction, I ext
         eventDao.clear();
 
         // save destinations
-        for (Destination item: response.getDestinations()) {
+        List<Destination> destinations = response.getDestinations();
+        Set<Integer> destinationIds = new HashSet<>(destinations.size());
+        for (Destination item : destinations) {
             item.setTimestamp(timestamp);
+            destinationIds.add(item.getId());
             destinationDao.save(item);
         }
 
         // save events
         for (Event item: response.getEvents()) {
+            // Work-around for published event with unpublished destination
+            if (item.getDestination() != null && !destinationIds.contains(item.getDestination())) {
+                item.setDestination(null);
+            }
             item.setTimestamp(timestamp);
             eventDao.save(item);
         }

--- a/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/com/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -13,7 +13,9 @@ import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationQueryResponse;
 import com.gophillygo.app.data.models.Event;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/app/src/main/java/com/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/com/gophillygo/app/di/AppComponent.java
@@ -21,6 +21,7 @@ import dagger.android.AndroidInjectionModule;
         AppModule.class,
 
         // Activities
+        EventDetailActivityModule.class,
         EventsListActivityModule.class,
         HomeActivityModule.class,
         PlaceDetailActivityModule.class,

--- a/app/src/main/java/com/gophillygo/app/di/EventDetailActivityModule.java
+++ b/app/src/main/java/com/gophillygo/app/di/EventDetailActivityModule.java
@@ -1,0 +1,13 @@
+package com.gophillygo.app.di;
+
+import com.gophillygo.app.activities.EventDetailActivity;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+
+@Module
+public abstract class EventDetailActivityModule {
+    @ContributesAndroidInjector
+    abstract EventDetailActivity contributeEventDetailActivity();
+}

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fillViewport="true"
+    tools:context="com.gophillygo.app.activities.EventDetailActivity">
+    <data>
+        <!-- set up data binding to event -->
+        <variable name="event" type="com.gophillygo.app.data.models.Event"/>
+        <variable name="eventInfo" type="com.gophillygo.app.data.models.EventInfo"/>
+        <variable name="destination" type="com.gophillygo.app.data.models.Destination"/>
+        <variable name="activity" type="com.gophillygo.app.activities.EventDetailActivity" />
+        <!-- imports to allow referencing within data binding expressions -->
+        <import type="android.view.View"/>
+    </data>
+    <ScrollView
+
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/event_detail_image"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="200dp"
+                app:imageUrl="@{event.getWideImage}"
+                android:contentDescription="@{event.getName}"
+                android:scaleType="centerCrop" />
+
+            <TextView
+                android:id="@+id/event_detail_item_name_label"
+                style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="start"
+                android:padding="10dp"
+                android:text="@{event.getName}"
+                app:layout_constraintBottom_toTopOf="@+id/event_detail_item_distance_label" />
+
+            <TextView
+                android:id="@+id/event_detail_item_distance_label"
+                style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_place_white_24px"
+                android:gravity="start"
+                android:paddingBottom="2dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
+                android:text='@{String.format("%.1f", eventInfo.distance) + " miles"}'
+                android:visibility="@{eventInfo.distance != null ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toBottomOf="@+id/event_detail_image" />
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/event_detail_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:minHeight="?attr/actionBarSize"
+                android:background="@null"
+                android:fitsSystemWindows="true"
+                android:elevation="4dp"
+                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                tools:targetApi="lollipop" />
+
+            <TextView
+                android:id="@+id/event_detail_date_label"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:paddingBottom="2dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
+                android:text='@{eventInfo != null ? activity.getEventTimeString() : ""}'
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_image" />
+
+            <TextView
+                android:id="@+id/event_detail_destination_name"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:paddingBottom="2dp"
+                android:paddingTop="10dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
+                android:text="@{eventInfo.destinationName}"
+                android:visibility="@{eventInfo.destinationName != null ? View.VISIBLE : View.GONE}"
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_date_label" />
+
+
+            <include
+                android:id="@+id/event_detail_description_card"
+                layout="@layout/detail_description"
+                android:layout_margin="10dp"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                app:htmlDescription="@{event.htmlDescription}"
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_destination_name" />
+
+            <android.support.v7.widget.CardView
+                android:id="@+id/event_detail_flag_options_card"
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_description_card"
+                android:layout_gravity="center"
+                android:layout_marginLeft="10dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginBottom="20dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/event_options_flag_text"
+                    android:text="@string/event_details_been_want_to_go_label"
+                    android:layout_width="match_parent"
+                    android:drawableEnd="@{activity.getFlagImage(eventInfo)}"
+                    style="@style/GpgDetailText" />
+
+            </android.support.v7.widget.CardView>
+
+            <LinearLayout
+                android:id="@+id/event_detail_button_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="center_horizontal"
+                android:paddingBottom="20dp"
+                android:paddingEnd="6dp"
+                android:paddingStart="6dp"
+                android:weightSum="3"
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_flag_options_card">
+
+                <android.support.v7.widget.AppCompatButton
+                    android:id="@+id/event_detail_map_button"
+                    style="@style/BorderlessDetailButton"
+                    android:layout_gravity="start"
+                    android:layout_weight="1"
+                    android:drawableStart="@drawable/ic_map_black_24dp"
+                    android:onClick="@{activity::goToMap}"
+                    android:text="@string/event_detail_map_button"
+                    android:visibility="@{destination != null ? View.VISIBLE : View.GONE}" />
+
+                <android.support.v7.widget.AppCompatButton
+                    android:id="@+id/event_detail_directions_button"
+                    style="@style/BorderlessDetailButton"
+                    android:layout_gravity="end"
+                    android:layout_weight="1"
+                    android:drawableStart="@drawable/ic_directions_black_24dp"
+                    android:onClick="@{activity::goToDirections}"
+                    android:text="@string/event_detail_directions_button"
+                    android:visibility="@{destination != null ? View.VISIBLE : View.GONE}" />
+
+                <android.support.v7.widget.AppCompatButton
+                    android:id="@+id/event_detail_website_button"
+                    style="@style/BorderlessDetailButton"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:drawableStart="@drawable/ic_public_black_24dp"
+                    android:onClick="@{activity::goToWebsite}"
+                    android:text="@string/event_detail_website_button"
+                    android:visibility="@{event.hasWebsite ? View.VISIBLE : View.GONE}" />
+            </LinearLayout>
+
+            <android.support.v7.widget.AppCompatButton
+                android:id="@+id/event_detail_calendar_button"
+                style="@style/BorderlessDetailButton"
+                android:layout_gravity="center_horizontal"
+                android:drawableStart="@drawable/ic_event_black_24dp"
+                android:onClick="@{activity::addToCalendar}"
+                android:text="@string/event_detail_add_to_calendar"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_button_bar" />
+
+        </android.support.constraint.ConstraintLayout>
+    </ScrollView>
+</layout>

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -79,37 +79,13 @@
                 style="@style/GpgDetailText"
                 android:visibility="@{destinationInfo.hasEvents ? View.VISIBLE : View.INVISIBLE}"/>
 
-            <android.support.v7.widget.CardView
+            <include layout="@layout/detail_description"
                 android:id="@+id/place_detail_description_card"
-                app:layout_constraintTop_toBottomOf="@+id/place_detail_upcoming_events"
-                android:layout_gravity="center"
                 android:layout_margin="10dp"
+                android:layout_height="wrap_content"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <android.support.constraint.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent">
-                    <TextView
-                        android:id="@+id/place_detail_description_text"
-                        android:ellipsize="end"
-                        android:maxLines="4"
-                        style="@style/GpgDetailText"
-                        android:text="@{destination.getHtmlDescription}"
-                        android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
-
-                    <TextView
-                        android:id="@+id/place_detail_description_toggle"
-                        android:text="@string/place_detail_description_expand"
-                        app:layout_constraintTop_toBottomOf="@id/place_detail_description_text"
-                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
-                        android:textAlignment="center"
-                        android:paddingTop="10sp"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-                </android.support.constraint.ConstraintLayout>
-
-            </android.support.v7.widget.CardView>
+                app:layout_constraintTop_toBottomOf="@+id/place_detail_upcoming_events"
+                app:htmlDescription="@{destination.htmlDescription}" />
 
             <android.support.v7.widget.CardView
                 android:id="@+id/place_detail_flag_options_card"

--- a/app/src/main/res/layout/detail_description.xml
+++ b/app/src/main/res/layout/detail_description.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:showIn="@layout/activity_place_detail">
+    <data>
+        <variable name="htmlDescription" type="android.text.Spanned" />
+    </data>
+    <android.support.v7.widget.CardView
+        android:layout_gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/detail_description_text"
+                android:ellipsize="end"
+                android:maxLines="4"
+                style="@style/GpgDetailText"
+                android:text="@{htmlDescription}"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+            <TextView
+                android:id="@+id/detail_description_toggle"
+                android:text="@string/detail_description_expand"
+                app:layout_constraintTop_toBottomOf="@id/detail_description_text"
+                android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
+                android:textAlignment="center"
+                android:paddingTop="10sp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,8 +48,20 @@
     <string name="place_detail_directions_button">Directions</string>
     <string name="place_detail_website_button">Website</string>
 
-    <string name="place_detail_description_expand">SHOW MORE</string>
-    <string name="place_detail_description_collapse">SHOW LESS</string>
+    <!-- event details -->
+    <string name="event_details_been_want_to_go_label">Want to go?</string>
+
+    <string name="event_detail_map_button">Map</string>
+    <string name="event_detail_directions_button">Directions</string>
+    <string name="event_detail_website_button">Website</string>
+
+    <string name="event_detail_single_day_time_range">%s • %s - %s</string>
+    <string name="event_detail_date_range">%s - %s</string>
+    <string name="event_detail_add_to_calendar">Add to calendar</string>
+
+    <!-- Details description -->
+    <string name="detail_description_expand">SHOW MORE</string>
+    <string name="detail_description_collapse">SHOW LESS</string>
 
     <!-- event list -->
     <string name="event_list_item_time_range">%s - %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="event_detail_single_day_time_range">%s • %s - %s</string>
     <string name="event_detail_date_range">%s - %s</string>
     <string name="event_detail_add_to_calendar">Add to calendar</string>
+    <string name="event_detail_no_calendar">No calendar application is installed.</string>
 
     <!-- Details description -->
     <string name="detail_description_expand">SHOW MORE</string>


### PR DESCRIPTION
## Overview
Adds event detail activity

## Screenshots
![screenshot_20180505-121027](https://user-images.githubusercontent.com/4432106/39667300-f23a5892-5080-11e8-9a5c-d28dcfe0a364.png)
![screenshot_20180505-121033](https://user-images.githubusercontent.com/4432106/39667301-f249f978-5080-11e8-9ed3-5fdbd6be7074.png)
![screenshot_20180505-121047](https://user-images.githubusercontent.com/4432106/39667302-f25ccbf2-5080-11e8-8155-2feaf851ee9b.png)
![screenshot_20180505-121056](https://user-images.githubusercontent.com/4432106/39667303-f26fa150-5080-11e8-8fff-c147999d0853.png)

## Notes

This is based on top of #51, I'll change the base branch once that PR is merged.

## Testing
 - You should be able to open an event from the event list activity and go to the detail activity
 - The destination name, distance, map and directions buttons should all appear if the event has a destination, and both buttons should work
 - the website button should appear if the event has a website, and it should work
 - the add to calendar buttons should work
 - setting the flag should work

Closes #20 
Closes #21