### PR TITLE
Use list async diff to keep scroll position

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Architecture Components
     def archComponentsVersion = '1.1.1'
-    def roomVersion = '1.0.0'
+    def roomVersion = '1.1.0'
     // ViewModel and LiveData
     implementation "android.arch.lifecycle:extensions:$archComponentsVersion"
     // Java8 support for Lifecycles
@@ -52,7 +52,7 @@ dependencies {
     implementation "com.android.support:design:$supportVersion"
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     // Android Play services libraries
-    def playServicesVersion = '15.0.0'
+    def playServicesVersion = '15.0.1'
     implementation "com.google.android.gms:play-services-location:$playServicesVersion"
     implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
     // Carousel
@@ -79,8 +79,8 @@ dependencies {
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     // testing
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     // Test helpers for LiveData
     testImplementation "android.arch.core:core-testing:$archComponentsVersion"
     // Test helpers for Room

--- a/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
@@ -103,7 +103,8 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     @NonNull
     private List<DestinationInfo> findNearestDestinations() {
 
-        if (currentLocation == null || destinationInfos == null || destinationInfos.isEmpty()) {
+        // getCurrentLocation will set to default if null
+        if (getCurrentLocation() == null || destinationInfos == null || destinationInfos.isEmpty()) {
             return new ArrayList<>();
         }
 
@@ -116,7 +117,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
         if (firstDestination.getDestination().getDistance() > 0) {
             // have distances; only update if location changed
             if (!locationHasChanged) {
-                Log.d(LOG_LABEL, "Have distances and location unchanged; not updating destinations");
+                Log.d(LOG_LABEL, "Have distances and location unchanged; not updating distances");
                 update = false;
             }
         }
@@ -195,6 +196,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     public Location getCurrentLocation() {
         if (currentLocation == null) {
             setDefaultLocation();
+            locationHasChanged = true;
         }
         return currentLocation;
     }

--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -67,7 +67,6 @@ public class EventsListActivity extends FilterableListActivity
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {
         eventInfo.updateAttractionFlag(item.getItemId());
         viewModel.updateAttractionFlag(eventInfo.getFlag());
-        eventsListView.getAdapter().notifyItemChanged(position);
         return true;
     }
 

--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -14,7 +14,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
-import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.EventsListAdapter;
 import com.gophillygo.app.data.EventViewModel;
@@ -39,6 +38,7 @@ public class EventsListActivity extends FilterableListActivity
     private LinearLayoutManager layoutManager;
     private RecyclerView eventsListView;
     private List<EventInfo> events;
+    private EventsListAdapter adapter;
 
     @SuppressWarnings("WeakerAccess")
     @Inject
@@ -76,6 +76,10 @@ public class EventsListActivity extends FilterableListActivity
         super.onCreate(savedInstanceState);
 
         layoutManager = new LinearLayoutManager(this);
+        eventsListView = findViewById(R.id.events_list_recycler_view);
+
+        // In addition to the destination data loaded by the BaseAttraction, get the full
+        // events data here.
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(EventViewModel.class);
         LiveData<Resource<List<EventInfo>>> data = viewModel.getEvents();
@@ -84,9 +88,6 @@ public class EventsListActivity extends FilterableListActivity
                     destinationResource.data != null && !destinationResource.data.isEmpty()) {
                 events = destinationResource.data;
                 loadData();
-                // Remove observer after loading full list so updates to the destination flags don't
-                // cause unwanted changes to scroll position
-                data.removeObservers(this);
             }
         });
     }
@@ -104,10 +105,16 @@ public class EventsListActivity extends FilterableListActivity
         TextView noDataView = findViewById(R.id.empty_events_list);
         noDataView.setVisibility(filteredEvents.isEmpty() ? View.VISIBLE : View.GONE);
 
-        eventsListView = findViewById(R.id.events_list_recycler_view);
-        EventsListAdapter adapter = new EventsListAdapter(this, filteredEvents, this);
-        eventsListView.setAdapter(adapter);
-        eventsListView.setLayoutManager(layoutManager);
+        // Reset list adapter if either it isn't set up, or if a filter was applied/removed.
+        if (adapter == null || filteredEvents.size() != adapter.getItemCount()) {
+            adapter = new EventsListAdapter(this, filteredEvents, this);
+            adapter.submitList(filteredEvents);
+            eventsListView.setAdapter(adapter);
+            eventsListView.setLayoutManager(layoutManager);
+        } else {
+            // Let the AsyncListDiffer find which have changed, and only update their view holders
+            adapter.submitList(filteredEvents);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
@@ -14,30 +14,22 @@ import android.widget.TextView;
 
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.PlacesListAdapter;
-import com.gophillygo.app.data.models.AttractionFlag;
 import com.gophillygo.app.data.models.AttractionInfo;
-import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.databinding.ActivityPlacesListBinding;
 import com.gophillygo.app.databinding.FilterButtonBarBinding;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class PlacesListActivity extends FilterableListActivity implements
         PlacesListAdapter.AttractionListItemClickListener {
 
     private static final String LOG_LABEL = "PlacesList";
-    private static final int RETURN_FROM_DETAIL_REQUEST = 301;
 
     private LinearLayoutManager layoutManager;
     private RecyclerView placesListView;
     PlacesListAdapter placesListAdapter;
-
-    // Track the ID of the destination last picked to view its details, so we can update it
-    // on return to this list, without having to reset the full list.
-    private long detailDestinationId = -1;
 
     public PlacesListActivity() {
         super(R.id.places_list_toolbar);
@@ -67,29 +59,15 @@ public class PlacesListActivity extends FilterableListActivity implements
      */
     public void clickedAttraction(int position) {
         // Get database ID for place clicked, based on positional offset, and pass it along
-        detailDestinationId = placesListView.getAdapter().getItemId(position);
+        long detailId = placesListView.getAdapter().getItemId(position);
         Intent intent = new Intent(this, PlaceDetailActivity.class);
-        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, detailDestinationId);
-        startActivityForResult(intent, RETURN_FROM_DETAIL_REQUEST);
+        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, detailId);
+        startActivity(intent);
     }
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo destinationInfo, Integer position) {
-        AttractionFlag lastFlag = destinationInfo.getFlag();
         destinationInfo.updateAttractionFlag(item.getItemId());
-        AttractionFlag flag = destinationInfo.getFlag();
-        viewModel.updateAttractionFlag(flag);
-
-        if (!Objects.equals(flag, lastFlag)) {
-            // Handle item disappearing from filtered list when filter condition changed.
-            if (filter.count() > 0 && filter.matches((DestinationInfo)destinationInfo)) {
-                placesListAdapter.notifyItemRemoved(position);
-            } else {
-                placesListAdapter.notifyItemChanged(position);
-            }
-        } else {
-            Log.d(LOG_LABEL, "Ignoring option being set to current value.");
-        }
-
+        viewModel.updateAttractionFlag(destinationInfo.getFlag());
         return true;
     }
 
@@ -166,40 +144,5 @@ public class PlacesListActivity extends FilterableListActivity implements
             }
         }
         return filteredDestinations;
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        // Update on returning from detail view for just the viewed destination.
-        // Allows keeping current list with scroll position, while refreshing the viewed
-        // destination, in case the user changed its flag.
-        if (requestCode == RETURN_FROM_DETAIL_REQUEST) {
-            Log.d(LOG_LABEL, "Returned to places list from place detail");
-            // update the single list item that may have changed
-            if (detailDestinationId > -1) {
-                final long destinationId = detailDestinationId;
-                detailDestinationId = -1; // reset now it has been handled
-                Log.d(LOG_LABEL, "Update viewed list item with ID " + destinationId);
-                for (int i = 0; i < destinationInfos.size(); i++) {
-                    Destination destination = destinationInfos.get(i).getDestination();
-                    if (destination.getId() == destinationId) {
-                        final int idx = i;
-                        viewModel.getDestination(destinationId).observe(this, (final DestinationInfo destinationInfo) -> {
-                            if (destinationInfo == null || destinationInfo.getDestination() == null) {
-                                Log.w(LOG_LABEL, "No matching destination found for ID " + destinationId);
-                                return;
-                            }
-
-                            Log.d(LOG_LABEL, "Found list index for place " + idx);
-                            destinationInfos.set(idx, destinationInfo);
-                            placesListAdapter.submitList(getFilteredDestinations());
-                        });
-                        break;
-                    }
-                }
-            }
-        } else {
-            Log.w(LOG_LABEL, "Unrecognized requestCode " + requestCode);
-        }
     }
 }

--- a/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
@@ -1,7 +1,5 @@
 package com.gophillygo.app.activities;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
@@ -14,41 +12,52 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
-import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.PlacesListAdapter;
-import com.gophillygo.app.data.DestinationViewModel;
+import com.gophillygo.app.data.models.AttractionFlag;
 import com.gophillygo.app.data.models.AttractionInfo;
+import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationInfo;
-import com.gophillygo.app.data.networkresource.Resource;
-import com.gophillygo.app.data.networkresource.Status;
 import com.gophillygo.app.databinding.ActivityPlacesListBinding;
 import com.gophillygo.app.databinding.FilterButtonBarBinding;
-import com.gophillygo.app.di.GpgViewModelFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.inject.Inject;
-
+import java.util.Objects;
 
 public class PlacesListActivity extends FilterableListActivity implements
         PlacesListAdapter.AttractionListItemClickListener {
 
     private static final String LOG_LABEL = "PlacesList";
+    private static final int RETURN_FROM_DETAIL_REQUEST = 301;
 
     private LinearLayoutManager layoutManager;
     private RecyclerView placesListView;
-    private List<DestinationInfo> destinations;
+    PlacesListAdapter placesListAdapter;
 
-    @SuppressWarnings("WeakerAccess")
-    @Inject
-    GpgViewModelFactory viewModelFactory;
-    @SuppressWarnings("WeakerAccess")
-    DestinationViewModel viewModel;
+    // Track the ID of the destination last picked to view its details, so we can update it
+    // on return to this list, without having to reset the full list.
+    private long detailDestinationId = -1;
 
     public PlacesListActivity() {
         super(R.id.places_list_toolbar);
+
+        // If destinations were loaded before this activity showed, use them immediately.
+        if (destinationInfos != null && !destinationInfos.isEmpty()) {
+            loadData();
+        } else {
+            Log.d(LOG_LABEL, "Have no destinations for the places list");
+        }
+    }
+
+    @Override
+    public void locationOrDestinationsChanged() {
+        super.locationOrDestinationsChanged();
+        if (destinationInfos != null && !destinationInfos.isEmpty()) {
+            loadData();
+        } else {
+            Log.d(LOG_LABEL, "Have no destinations for the places list in locationOrDestinationsChanged");
+        }
     }
 
     /**
@@ -58,16 +67,29 @@ public class PlacesListActivity extends FilterableListActivity implements
      */
     public void clickedAttraction(int position) {
         // Get database ID for place clicked, based on positional offset, and pass it along
-        long destinationId = placesListView.getAdapter().getItemId(position);
+        detailDestinationId = placesListView.getAdapter().getItemId(position);
         Intent intent = new Intent(this, PlaceDetailActivity.class);
-        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, destinationId);
-        startActivity(intent);
+        intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, detailDestinationId);
+        startActivityForResult(intent, RETURN_FROM_DETAIL_REQUEST);
     }
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo destinationInfo, Integer position) {
+        AttractionFlag lastFlag = destinationInfo.getFlag();
         destinationInfo.updateAttractionFlag(item.getItemId());
-        viewModel.updateAttractionFlag(destinationInfo.getFlag());
-        placesListView.getAdapter().notifyItemChanged(position);
+        AttractionFlag flag = destinationInfo.getFlag();
+        viewModel.updateAttractionFlag(flag);
+
+        if (!Objects.equals(flag, lastFlag)) {
+            // Handle item disappearing from filtered list when filter condition changed.
+            if (filter.count() > 0 && filter.matches((DestinationInfo)destinationInfo)) {
+                placesListAdapter.notifyItemRemoved(position);
+            } else {
+                placesListAdapter.notifyItemChanged(position);
+            }
+        } else {
+            Log.d(LOG_LABEL, "Ignoring option being set to current value.");
+        }
+
         return true;
     }
 
@@ -77,20 +99,7 @@ public class PlacesListActivity extends FilterableListActivity implements
 
         // set up list of places
         layoutManager = new LinearLayoutManager(this);
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
-                .get(DestinationViewModel.class);
-
-        LiveData<Resource<List<DestinationInfo>>> data = viewModel.getDestinations();
-        data.observe(this, destinationResource -> {
-            if (destinationResource != null && destinationResource.status.equals(Status.SUCCESS) &&
-                    destinationResource.data != null && !destinationResource.data.isEmpty()) {
-                destinations = destinationResource.data;
-                loadData();
-                // Remove observer after loading full list so updates to the destination flags don't
-                // cause unwanted changes to scroll position
-                data.removeObservers(this);
-            }
-        });
+        placesListView = findViewById(R.id.places_list_recycler_view);
     }
 
     @Override
@@ -101,15 +110,24 @@ public class PlacesListActivity extends FilterableListActivity implements
 
     @Override
     protected void loadData() {
+        Log.d(LOG_LABEL, "loadData");
         List<DestinationInfo> filteredDestinations = getFilteredDestinations();
-
         TextView noDataView = findViewById(R.id.empty_places_list);
         noDataView.setVisibility(filteredDestinations.isEmpty() ? View.VISIBLE : View.GONE);
 
-        placesListView = findViewById(R.id.places_list_recycler_view);
-        PlacesListAdapter adapter = new PlacesListAdapter(this, filteredDestinations, this);
-        placesListView.setAdapter(adapter);
-        placesListView.setLayoutManager(layoutManager);
+        // Reset list adapter if either it isn't set up, or if a filter was applied/removed.
+        if (placesListAdapter == null || filteredDestinations.size() != placesListAdapter.getItemCount()) {
+            placesListAdapter = new PlacesListAdapter(this, filteredDestinations, this);
+            // must set the list before the adapter for the differ to initialize properly
+            placesListAdapter.submitList(filteredDestinations);
+            placesListView.setAdapter(placesListAdapter);
+            placesListView.setLayoutManager(layoutManager);
+        } else {
+            Log.d(LOG_LABEL, "submit list for diff");
+            // Let the AsyncListDiffer find which have changed, and only update their view holders
+            // https://developer.android.com/reference/android/support/v7/recyclerview/extensions/ListAdapter
+            placesListAdapter.submitList(filteredDestinations);
+        }
     }
 
     @Override
@@ -140,9 +158,9 @@ public class PlacesListActivity extends FilterableListActivity implements
     }
 
     @NonNull
-    private List<DestinationInfo> getFilteredDestinations() {
-        List<DestinationInfo> filteredDestinations = new ArrayList<>(destinations.size());
-        for (DestinationInfo info : destinations) {
+    private ArrayList<DestinationInfo> getFilteredDestinations() {
+        ArrayList<DestinationInfo> filteredDestinations = new ArrayList<>(destinationInfos.size());
+        for (DestinationInfo info : destinationInfos) {
             if (filter.matches(info)) {
                 filteredDestinations.add(info);
             }
@@ -150,4 +168,38 @@ public class PlacesListActivity extends FilterableListActivity implements
         return filteredDestinations;
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // Update on returning from detail view for just the viewed destination.
+        // Allows keeping current list with scroll position, while refreshing the viewed
+        // destination, in case the user changed its flag.
+        if (requestCode == RETURN_FROM_DETAIL_REQUEST) {
+            Log.d(LOG_LABEL, "Returned to places list from place detail");
+            // update the single list item that may have changed
+            if (detailDestinationId > -1) {
+                final long destinationId = detailDestinationId;
+                detailDestinationId = -1; // reset now it has been handled
+                Log.d(LOG_LABEL, "Update viewed list item with ID " + destinationId);
+                for (int i = 0; i < destinationInfos.size(); i++) {
+                    Destination destination = destinationInfos.get(i).getDestination();
+                    if (destination.getId() == destinationId) {
+                        final int idx = i;
+                        viewModel.getDestination(destinationId).observe(this, (final DestinationInfo destinationInfo) -> {
+                            if (destinationInfo == null || destinationInfo.getDestination() == null) {
+                                Log.w(LOG_LABEL, "No matching destination found for ID " + destinationId);
+                                return;
+                            }
+
+                            Log.d(LOG_LABEL, "Found list index for place " + idx);
+                            destinationInfos.set(idx, destinationInfo);
+                            placesListAdapter.submitList(getFilteredDestinations());
+                        });
+                        break;
+                    }
+                }
+            }
+        } else {
+            Log.w(LOG_LABEL, "Unrecognized requestCode " + requestCode);
+        }
+    }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -9,6 +9,7 @@ import android.text.Spanned;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 
 @Entity
@@ -154,5 +155,33 @@ public class Attraction {
             stringBuilder.append(activity);
         }
         return stringBuilder.toString();
+    }
+
+    // Implement equals and hashcode for list adapter to diff.
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Attraction that = (Attraction) o;
+        return id == that.id &&
+                placeID == that.placeID &&
+                accessible == that.accessible &&
+                cycling == that.cycling &&
+                priority == that.priority &&
+                isEvent == that.isEvent &&
+                timestamp == that.timestamp &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(image, that.image) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(activities, that.activities) &&
+                Objects.equals(websiteUrl, that.websiteUrl) &&
+                Objects.equals(wideImage, that.wideImage);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id, placeID, name, accessible, image, cycling, description, priority, activities, websiteUrl, wideImage, isEvent, timestamp);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/AttractionFlag.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/AttractionFlag.java
@@ -11,6 +11,8 @@ import android.util.SparseArray;
 import com.google.gson.annotations.SerializedName;
 import com.gophillygo.app.R;
 
+import java.util.Objects;
+
 @Entity(primaryKeys = {"attractionID", "is_event"})
 public class AttractionFlag {
 
@@ -81,6 +83,22 @@ public class AttractionFlag {
         public static int toInt(Option option) {
             return option.code;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AttractionFlag that = (AttractionFlag) o;
+        return attractionID == that.attractionID &&
+                isEvent == that.isEvent &&
+                option == that.option;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(attractionID, isEvent, option);
     }
 }
 

--- a/app/src/main/java/com/gophillygo/app/data/models/AttractionInfo.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/AttractionInfo.java
@@ -7,6 +7,8 @@ import android.support.annotation.MenuRes;
 
 import com.gophillygo.app.R;
 
+import java.util.Objects;
+
 public abstract class AttractionInfo<T extends Attraction> {
     @Ignore
     protected AttractionFlag flag;
@@ -59,5 +61,20 @@ public abstract class AttractionInfo<T extends Attraction> {
 
     public AttractionFlag.Option getOption() {
         return option;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AttractionInfo<?> that = (AttractionInfo<?>) o;
+        return Objects.equals(flag, that.flag) &&
+                option == that.option;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(flag, option);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/AttractionInfo.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/AttractionInfo.java
@@ -30,6 +30,10 @@ public abstract class AttractionInfo<T extends Attraction> {
         return flag;
     }
 
+    public void setFlag(AttractionFlag flag) {
+        this.flag = flag;
+    }
+
     public @DrawableRes int getFlagImage() {
         return flag == null || flag.getOption() == null ? AttractionFlag.Option.NotSelected.drawable : flag.getOption().drawable;
     }
@@ -66,15 +70,15 @@ public abstract class AttractionInfo<T extends Attraction> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof AttractionInfo)) return false;
         AttractionInfo<?> that = (AttractionInfo<?>) o;
         return Objects.equals(flag, that.flag) &&
-                option == that.option;
+                option == that.option &&
+                Objects.equals(getAttraction(), that.getAttraction());
     }
 
     @Override
     public int hashCode() {
-
         return Objects.hash(flag, option);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Destination.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Destination.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Objects;
 
 
 @Entity(inheritSuperIndices = true)
@@ -110,5 +111,29 @@ public class Destination extends Attraction {
 
     public ArrayList<String> getCategories() {
         return categories;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        Destination that = (Destination) o;
+        return watershedAlliance == that.watershedAlliance &&
+                Float.compare(that.distance, distance) == 0 &&
+                Objects.equals(city, that.city) &&
+                Objects.equals(state, that.state) &&
+                Objects.equals(address, that.address) &&
+                Objects.equals(categories, that.categories) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(attributes, that.attributes) &&
+                Objects.equals(zipCode, that.zipCode) &&
+                Objects.equals(formattedDistance, that.formattedDistance);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), city, state, address, categories, location, watershedAlliance, attributes, zipCode, distance, formattedDistance);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/DestinationAttributes.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/DestinationAttributes.java
@@ -4,6 +4,8 @@ import android.arch.persistence.room.ColumnInfo;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 /**
  * Extra destination attributes on a sub-property, including street address.
  */
@@ -20,5 +22,19 @@ public class DestinationAttributes {
 
     public String getStreetAddress() {
         return streetAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DestinationAttributes that = (DestinationAttributes) o;
+        return Objects.equals(streetAddress, that.streetAddress);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(streetAddress);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/DestinationInfo.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/DestinationInfo.java
@@ -2,6 +2,8 @@ package com.gophillygo.app.data.models;
 
 import android.arch.persistence.room.Embedded;
 
+import java.util.Objects;
+
 public class DestinationInfo extends AttractionInfo<Destination> {
     @Embedded
     private final Destination destination;
@@ -32,4 +34,19 @@ public class DestinationInfo extends AttractionInfo<Destination> {
         return eventCount > 0;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        DestinationInfo that = (DestinationInfo) o;
+        return eventCount == that.eventCount &&
+                Objects.equals(destination, that.destination);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), destination, eventCount);
+    }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/DestinationLocation.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/DestinationLocation.java
@@ -1,5 +1,7 @@
 package com.gophillygo.app.data.models;
 
+import java.util.Objects;
+
 /**
  * Holds the coordinates of a destination
  */
@@ -25,5 +27,20 @@ public class DestinationLocation {
     @Override
     public String toString() {
         return getY() + "," + getX();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DestinationLocation that = (DestinationLocation) o;
+        return Double.compare(that.x, x) == 0 &&
+                Double.compare(that.y, y) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(x, y);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/DestinationQueryResponse.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/DestinationQueryResponse.java
@@ -1,6 +1,7 @@
 package com.gophillygo.app.data.models;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper for the destinations query response, which contains destinations and events
@@ -22,5 +23,20 @@ public class DestinationQueryResponse {
     public DestinationQueryResponse(List<Destination> destinations, List<Event> events) {
         this.destinations = destinations;
         this.events = events;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DestinationQueryResponse that = (DestinationQueryResponse) o;
+        return Objects.equals(destinations, that.destinations) &&
+                Objects.equals(events, that.events);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(destinations, events);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 import static android.arch.persistence.room.ForeignKey.SET_NULL;
 
@@ -132,5 +133,25 @@ public class Event extends Attraction {
 
         return startCalendar.get(Calendar.YEAR) == endCalendar.get(Calendar.YEAR) &&
                 startCalendar.get(Calendar.DAY_OF_YEAR) == endCalendar.get(Calendar.DAY_OF_YEAR);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        Event event = (Event) o;
+        return isSingleDay == event.isSingleDay &&
+                Objects.equals(destination, event.destination) &&
+                Objects.equals(startDate, event.startDate) &&
+                Objects.equals(endDate, event.endDate) &&
+                Objects.equals(start, event.start) &&
+                Objects.equals(end, event.end);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), destination, startDate, endDate, start, end, isSingleDay);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/EventInfo.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/EventInfo.java
@@ -3,6 +3,7 @@ package com.gophillygo.app.data.models;
 import android.arch.persistence.room.Embedded;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class EventInfo extends AttractionInfo<Event> {
     @Embedded
@@ -45,5 +46,23 @@ public class EventInfo extends AttractionInfo<Event> {
 
     public Float getDistance() {
         return distance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EventInfo eventInfo = (EventInfo) o;
+        return Objects.equals(event, eventInfo.event) &&
+                Objects.equals(destinationName, eventInfo.destinationName) &&
+                Objects.equals(destinationCategories, eventInfo.destinationCategories) &&
+                Objects.equals(distance, eventInfo.distance);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), event, destinationName, destinationCategories, distance);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/data/models/Filter.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Filter.java
@@ -6,6 +6,7 @@ import android.databinding.Bindable;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.gophillygo.app.BR;
 
@@ -224,5 +225,26 @@ public class Filter extends BaseObservable implements Serializable {
     public void setAccessible(boolean accessible) {
         this.accessible = accessible;
         notifyPropertyChanged(BR.accessible);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Filter filter = (Filter) o;
+        return nature == filter.nature &&
+                exercise == filter.exercise &&
+                educational == filter.educational &&
+                been == filter.been &&
+                wantToGo == filter.wantToGo &&
+                notInterested == filter.notInterested &&
+                liked == filter.liked &&
+                accessible == filter.accessible;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(nature, exercise, educational, been, wantToGo, notInterested, liked, accessible);
     }
 }

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -46,7 +46,7 @@
                 style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:drawableStart="@drawable/ic_place_white_24px"
+                android:drawableStart="@drawable/ic_place_white_24dp"
                 android:gravity="start"
                 android:paddingBottom="2dp"
                 android:paddingEnd="10dp"


### PR DESCRIPTION
Retain live data listeners.

Change list adapter type to use [AsyncListDiffer](https://developer.android.com/reference/android/support/v7/recyclerview/extensions/AsyncListDiffer) to only update records as needed when using `LiveData`. This list adapter is intended for use with `LiveData` sources. This is the best way to deal with `LiveData` in a `RecyclerView`, according to [this Android dev](https://medium.com/@ianhlake/diffutil-is-indeed-the-way-to-do-update-a-list-backed-by-livedata-22fe0365a540). This also fixes the issues with flags being out of sync on view switch (#53).

Also fixes the secondary destinations observer on the places list view inadvertently left in during the refactor to the shared base class.

Fixes #53.