### PR TITLE
Notify list view on flag change

### DIFF
--- a/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventsListActivity.java
@@ -67,6 +67,7 @@ public class EventsListActivity extends FilterableListActivity
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {
         eventInfo.updateAttractionFlag(item.getItemId());
         viewModel.updateAttractionFlag(eventInfo.getFlag());
+        adapter.notifyItemChanged(position);
         return true;
     }
 

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -116,7 +116,6 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
             menu.setOnMenuItemClickListener(item -> {
                 destinationInfo.updateAttractionFlag(item.getItemId());
                 viewModel.updateAttractionFlag(destinationInfo.getFlag());
-
                 return true;
             });
         });

--- a/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlacesListActivity.java
@@ -68,6 +68,7 @@ public class PlacesListActivity extends FilterableListActivity implements
     public boolean clickedFlagOption(MenuItem item, AttractionInfo destinationInfo, Integer position) {
         destinationInfo.updateAttractionFlag(item.getItemId());
         viewModel.updateAttractionFlag(destinationInfo.getFlag());
+        placesListAdapter.notifyItemChanged(position);
         return true;
     }
 


### PR DESCRIPTION
Fix to the refactor in #63.
Adds back `notifyItemChanged` calls for list view items to update consistently.

(It sometimes works without the notify call, inconsistently, but it is still necessary to call it.)

Trivial; merging.