### PR TITLE
Show extra images in carousel on detail screens

### DIFF
--- a/app/schemas/com.gophillygo.app.data.GpgDatabase/10.json
+++ b/app/schemas/com.gophillygo.app.data.GpgDatabase/10.json
@@ -1,0 +1,455 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "119508ef1a9b5d86599108aeb0f7fdc4",
+    "entities": [
+      {
+        "tableName": "AttractionFlag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`attractionID` INTEGER NOT NULL, `is_event` INTEGER NOT NULL, `option` INTEGER, PRIMARY KEY(`attractionID`, `is_event`))",
+        "fields": [
+          {
+            "fieldPath": "attractionID",
+            "columnName": "attractionID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "option",
+            "columnName": "option",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "attractionID",
+            "is_event"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_AttractionFlag_attractionID",
+            "unique": false,
+            "columnNames": [
+              "attractionID"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_attractionID` ON `${TABLE_NAME}` (`attractionID`)"
+          },
+          {
+            "name": "index_AttractionFlag_is_event",
+            "unique": false,
+            "columnNames": [
+              "is_event"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_is_event` ON `${TABLE_NAME}` (`is_event`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Destination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT, `state` TEXT, `address` TEXT, `categories` TEXT, `watershed_alliance` INTEGER NOT NULL, `zipcode` TEXT, `distance` REAL NOT NULL, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, `x` REAL, `y` REAL, `street_address` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watershedAlliance",
+            "columnName": "watershed_alliance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipCode",
+            "columnName": "zipcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.x",
+            "columnName": "x",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.y",
+            "columnName": "y",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attributes.streetAddress",
+            "columnName": "street_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Destination_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Destination_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Destination_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Destination_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Destination_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `start_date` TEXT, `end_date` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Event_destination",
+            "unique": false,
+            "columnNames": [
+              "destination"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_destination` ON `${TABLE_NAME}` (`destination`)"
+          },
+          {
+            "name": "index_Event_start_date",
+            "unique": false,
+            "columnNames": [
+              "start_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_start_date` ON `${TABLE_NAME}` (`start_date`)"
+          },
+          {
+            "name": "index_Event_end_date",
+            "unique": false,
+            "columnNames": [
+              "end_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_end_date` ON `${TABLE_NAME}` (`end_date`)"
+          },
+          {
+            "name": "index_Event_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Event_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Event_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Event_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Event_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Destination",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "destination"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"119508ef1a9b5d86599108aeb0f7fdc4\")"
+    ]
+  }
+}

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -1,5 +1,6 @@
 package com.gophillygo.app.activities;
 
+import android.arch.persistence.room.util.StringUtil;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -8,6 +9,7 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
@@ -22,6 +24,7 @@ import com.synnapps.carouselview.CarouselView;
 abstract class AttractionDetailActivity extends AppCompatActivity {
     protected static final int COLLAPSED_LINE_COUNT = 4;
     protected static final int EXPANDED_MAX_LINES = 50;
+    private static final String LOG_LABEL = "AttractionDetail";
     protected DestinationInfo destinationInfo;
 
     protected View.OnClickListener toggleClickListener;
@@ -94,11 +97,17 @@ abstract class AttractionDetailActivity extends AppCompatActivity {
 
     public void setupCarousel(CarouselView carouselView, Attraction attraction) {
         carouselView.setImageListener((position, imageView) -> {
-            String url;
+            String url = null;
             if (position == 0) {
                 url = attraction.getWideImage();
-            } else {
+            } else if (position <= attraction.getExtraWideImages().size()) {
                 url = attraction.getExtraWideImages().get(position - 1);
+            }
+            // Shouldn't be possible to reach this, but re-use the wide image if the extra images are blank
+            // or there aren't enough of them
+            if (url == null || url.equals("")) {
+                Log.e(LOG_LABEL, "Unexpected missing extra image for attraction: " + attraction.getId());
+                url = attraction.getWideImage();
             }
             Glide.with(this).load(url).into(imageView);
         });

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -11,10 +11,13 @@ import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.widget.TextView;
 
+import com.bumptech.glide.Glide;
 import com.gophillygo.app.R;
+import com.gophillygo.app.data.models.Attraction;
 import com.gophillygo.app.data.models.AttractionInfo;
 import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.data.models.DestinationLocation;
+import com.synnapps.carouselview.CarouselView;
 
 abstract class AttractionDetailActivity extends AppCompatActivity {
     protected static final int COLLAPSED_LINE_COUNT = 4;
@@ -87,5 +90,18 @@ abstract class AttractionDetailActivity extends AppCompatActivity {
         if (attractionInfo == null) return null;
 
         return ContextCompat.getDrawable(this, attractionInfo.getFlagImage());
+    }
+
+    public void setupCarousel(CarouselView carouselView, Attraction attraction) {
+        carouselView.setImageListener((position, imageView) -> {
+            String url;
+            if (position == 0) {
+                url = attraction.getWideImage();
+            } else {
+                url = attraction.getExtraWideImages().get(position - 1);
+            }
+            Glide.with(this).load(url).into(imageView);
+        });
+        carouselView.setPageCount(attraction.getExtraWideImages().size() + 1);
     }
 }

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -38,7 +38,6 @@ import javax.inject.Inject;
 public class EventDetailActivity extends AttractionDetailActivity {
 
     public static final String EVENT_ID_KEY = "eventId";
-    protected final Class MAP_ACTIVITY = PlacesMapsActivity.class;
     private static final String LOG_LABEL = "EventDetail";
 
     private static final DateFormat timeFormat, monthDayFormat;

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -12,6 +12,7 @@ import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -26,6 +27,7 @@ import com.gophillygo.app.databinding.ActivityEventDetailBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 import com.gophillygo.app.utils.FlagMenuUtils;
 import com.gophillygo.app.utils.UserUuidUtils;
+import com.synnapps.carouselview.CarouselView;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -60,6 +62,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
     EventViewModel viewModel;
     @SuppressWarnings("WeakerAccess")
     DestinationViewModel destinationViewModel;
+    private CarouselView carouselView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -82,6 +85,9 @@ public class EventDetailActivity extends AttractionDetailActivity {
             Log.e(LOG_LABEL, "Event not found when attempting to load detail view.");
             finish();
         }
+
+        carouselView = findViewById(R.id.event_detail_carousel);
+        carouselView.setIndicatorGravity(Gravity.CENTER_HORIZONTAL|Gravity.BOTTOM);
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
         destinationViewModel = ViewModelProviders.of(this, viewModelFactory).get(DestinationViewModel.class);
@@ -168,6 +174,8 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
     @SuppressLint({"RestrictedApi", "RtlHardcoded"})
     private void displayEvent() {
+        setupCarousel(carouselView, eventInfo.getEvent());
+
         TextView descriptionToggle = findViewById(R.id.detail_description_toggle);
         descriptionToggle.setOnClickListener(toggleClickListener);
 

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -11,10 +11,8 @@ import android.util.Log;
 import android.view.Gravity;
 import android.widget.TextView;
 
-import com.gophillygo.app.CarouselViewListener;
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
-import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.databinding.ActivityPlaceDetailBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 import com.gophillygo.app.utils.FlagMenuUtils;
@@ -65,8 +63,6 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
 
         carouselView = findViewById(R.id.place_detail_carousel);
         carouselView.setIndicatorGravity(Gravity.CENTER_HORIZONTAL|Gravity.BOTTOM);
-        carouselView.setImageClickListener(position ->
-                Log.d(LOG_LABEL, "Clicked item: "+ position));
 
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(DestinationViewModel.class);
@@ -90,14 +86,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
 
     @SuppressLint({"RestrictedApi", "RtlHardcoded"})
     private void displayDestination() {
-        // set up carousel
-        carouselView.setViewListener(new CarouselViewListener(this, false) {
-            @Override
-            public Destination getDestinationAt(int position) {
-                return destinationInfo.getDestination();
-            }
-        });
-        carouselView.setPageCount(1);
+        setupCarousel(carouselView, destinationInfo.getDestination());
 
         TextView descriptionToggle = findViewById(R.id.detail_description_toggle);
         descriptionToggle.setOnClickListener(toggleClickListener);

--- a/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
+++ b/app/src/main/java/com/gophillygo/app/data/GpgDatabase.java
@@ -8,7 +8,7 @@ import com.gophillygo.app.data.models.AttractionFlag;
 import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.Event;
 
-@Database(version=9, entities={AttractionFlag.class, Destination.class, Event.class})
+@Database(version=10, entities={AttractionFlag.class, Destination.class, Event.class})
 @TypeConverters({RoomConverters.class})
 public abstract class GpgDatabase extends RoomDatabase {
     abstract public DestinationDao destinationDao();

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -81,6 +81,9 @@ public class Attraction {
      */
     private String addHostToPath(@NonNull String path) {
         if (!path.isEmpty() && !path.startsWith("http")) {
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
             return DestinationWebservice.WEBSERVICE_URL.concat(path);
         }
         return path;

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -51,12 +51,17 @@ public class Attraction {
     @SerializedName("is_event")
     private final boolean isEvent;
 
+    @ColumnInfo(name = "extra_wide_images")
+    @SerializedName("extra_wide_images")
+    private final ArrayList<String> extraWideImages;
+
     // timestamp is not final, as it is set on database save, and not by serializer
     private long timestamp;
 
     public Attraction(int id, int placeID, String name, boolean accessible, String image,
                       boolean cycling, String description, int priority, String websiteUrl,
-                      String wideImage, boolean isEvent, ArrayList<String> activities) {
+                      String wideImage, boolean isEvent, ArrayList<String> activities,
+                      ArrayList<String> extraWideImages) {
         this.id = id;
         this.placeID = placeID;
         this.name = name;
@@ -66,10 +71,14 @@ public class Attraction {
         this.description = description;
         this.priority = priority;
         this.websiteUrl = websiteUrl;
-        this.wideImage = wideImage;
         this.isEvent = isEvent;
-
         this.activities = activities;
+
+        this.wideImage = addHostToPath(wideImage);
+        this.extraWideImages = new ArrayList<>(extraWideImages.size());
+        for (String url : extraWideImages) {
+            this.extraWideImages.add(addHostToPath(url));
+        }
     }
 
 
@@ -144,11 +153,15 @@ public class Attraction {
     }
 
     public String getWideImage() {
-        return addHostToPath(wideImage);
+        return wideImage;
     }
 
     public boolean isEvent() {
         return isEvent;
+    }
+
+    public ArrayList<String> getExtraWideImages() {
+        return extraWideImages;
     }
 
     public long getTimestamp() {
@@ -211,7 +224,8 @@ public class Attraction {
                 Objects.equals(description, that.description) &&
                 Objects.equals(activities, that.activities) &&
                 Objects.equals(websiteUrl, that.websiteUrl) &&
-                Objects.equals(wideImage, that.wideImage);
+                Objects.equals(wideImage, that.wideImage) &&
+                Objects.equals(extraWideImages, that.extraWideImages);
     }
 
     @Override

--- a/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Attraction.java
@@ -9,9 +9,11 @@ import android.text.Html;
 import android.text.Spanned;
 
 import com.google.gson.annotations.SerializedName;
+import com.gophillygo.app.BuildConfig;
 import com.gophillygo.app.data.DestinationWebservice;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -74,11 +76,8 @@ public class Attraction {
         this.isEvent = isEvent;
         this.activities = activities;
 
-        this.wideImage = addHostToPath(wideImage);
-        this.extraWideImages = new ArrayList<>(extraWideImages.size());
-        for (String url : extraWideImages) {
-            this.extraWideImages.add(addHostToPath(url));
-        }
+        this.wideImage = wideImage;
+        this.extraWideImages = extraWideImages;
     }
 
 
@@ -153,7 +152,7 @@ public class Attraction {
     }
 
     public String getWideImage() {
-        return wideImage;
+        return BuildConfig.DEBUG ? addHostToPath(wideImage) : wideImage;
     }
 
     public boolean isEvent() {
@@ -161,7 +160,15 @@ public class Attraction {
     }
 
     public ArrayList<String> getExtraWideImages() {
-        return extraWideImages;
+        if (!BuildConfig.DEBUG) {
+            return extraWideImages;
+        }
+
+        ArrayList<String> imagesWithHost = new ArrayList<>(extraWideImages.size());
+        for (String url : extraWideImages) {
+            imagesWithHost.add(addHostToPath(url));
+        }
+        return imagesWithHost;
     }
 
     public long getTimestamp() {

--- a/app/src/main/java/com/gophillygo/app/data/models/Destination.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Destination.java
@@ -51,11 +51,11 @@ public class Destination extends Attraction {
                        int priority, String state, String address, DestinationLocation location,
                        DestinationAttributes attributes, boolean watershedAlliance, String websiteUrl,
                        String wideImage, boolean isEvent, ArrayList<String> activities,
-                       ArrayList<String> categories) {
+                       ArrayList<String> categories, ArrayList<String> extraWideImages) {
 
         // initialize Attraction
         super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
-              wideImage, isEvent, activities);
+              wideImage, isEvent, activities, extraWideImages);
 
         this.city = city;
         this.zipCode = zipCode;

--- a/app/src/main/java/com/gophillygo/app/data/models/Event.java
+++ b/app/src/main/java/com/gophillygo/app/data/models/Event.java
@@ -59,11 +59,11 @@ public class Event extends Attraction {
     public Event(int id, int placeID, String name, boolean accessible, String image,
                  boolean cycling, String description, int priority, String websiteUrl,
                  String wideImage, boolean isEvent, ArrayList<String> activities,
-                 Integer destination, String startDate, String endDate) {
+                 Integer destination, String startDate, String endDate, ArrayList<String> extraWideImages) {
 
         // initialize Attraction
         super(id, placeID, name, accessible, image, cycling, description, priority, websiteUrl,
-              wideImage, isEvent, activities);
+              wideImage, isEvent, activities, extraWideImages);
 
         this.destination = destination;
         this.startDate = startDate;

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -22,14 +22,19 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <ImageView
-                android:id="@+id/event_detail_image"
+            <com.synnapps.carouselview.CarouselView
+                android:id="@+id/event_detail_carousel"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="200dp"
-                app:imageUrl="@{event.getWideImage}"
-                android:contentDescription="@{event.getName}"
-                android:scaleType="centerCrop" />
+                android:layout_height="200dp"
+                app:fillColor="@color/color_white"
+                app:pageColor="@color/color_background_grey"
+                app:radius="3dp"
+                app:slideInterval="4000"
+                app:strokeColor="@color/color_background_grey"
+                app:indicatorGravity="bottom"
+                app:indicatorMarginVertical="10dp"
+                app:indicatorMarginHorizontal="5dp"
+                app:strokeWidth="0dp" />
 
             <TextView
                 android:id="@+id/event_detail_item_name_label"
@@ -37,7 +42,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="start"
-                android:padding="10dp"
+                android:paddingBottom="2dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
                 android:text="@{event.getName}"
                 app:layout_constraintBottom_toTopOf="@+id/event_detail_item_distance_label" />
 
@@ -53,7 +60,7 @@
                 android:paddingStart="10dp"
                 android:text='@{eventInfo.formattedDistance}'
                 android:visibility="@{eventInfo.distance != null ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toBottomOf="@+id/event_detail_image" />
+                app:layout_constraintBottom_toBottomOf="@+id/event_detail_carousel" />
 
             <android.support.v7.widget.Toolbar
                 android:id="@+id/event_detail_toolbar"
@@ -79,7 +86,7 @@
                 android:paddingEnd="10dp"
                 android:paddingStart="10dp"
                 android:text='@{eventInfo != null ? activity.getEventTimeString() : ""}'
-                app:layout_constraintTop_toBottomOf="@+id/event_detail_image" />
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_carousel" />
 
             <TextView
                 android:id="@+id/event_detail_destination_name"

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -34,6 +34,29 @@
                 app:indicatorMarginHorizontal="5dp"
                 app:strokeWidth="0dp" />
 
+            <TextView
+                android:id="@+id/place_detail_name_label"
+                style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="2dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
+                android:text="@{destination.getAddress}"
+                app:layout_constraintBottom_toTopOf="@+id/place_detail_distance_label" />
+
+            <TextView
+                android:id="@+id/place_detail_distance_label"
+                style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_place_white_24dp"
+                android:paddingBottom="2dp"
+                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
+                android:text="@{destination.getFormattedDistance}"
+                app:layout_constraintBottom_toBottomOf="@+id/place_detail_carousel" />
+
             <android.support.v7.widget.Toolbar
                 android:id="@+id/place_detail_toolbar"
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Overview

Adds support for showing multiple images on the event and destination detail activites

## Testing
 - Temporarily change `DestinationWebService` to use your local VM
 - Add extra images to both an event and a destination
 - Ensure that events and destinations with extra images display a carousel that shows each image one-by-one
 - Ensure that events and destinations without extra images


Closes #56