### PR TITLE
Fix pluralization of filter button title

### DIFF
--- a/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
@@ -86,10 +86,6 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
         } else {
             filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
         }
-        String filterTitle = getResources()
-                .getQuantityString(R.plurals.filter_button_title, setFilterCount);
-        filterButton.setText(filterTitle);
-
     }
 
     @Override

--- a/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/FilterableListActivity.java
@@ -86,6 +86,9 @@ public abstract class FilterableListActivity extends BaseAttractionActivity
         } else {
             filterButton.setCompoundDrawablesWithIntrinsicBounds(filterIcon, null, null, null);
         }
+        String filterTitle = getResources()
+                .getQuantityString(R.plurals.filter_button_title, setFilterCount);
+        filterButton.setText(filterTitle);
 
     }
 

--- a/app/src/main/res/layout/filter_button_bar.xml
+++ b/app/src/main/res/layout/filter_button_bar.xml
@@ -21,7 +21,7 @@
             android:background="@drawable/toggle_button_toolbar_unchecked"
             android:drawableStart="@drawable/ic_filter_list_white_24dp"
             style="@style/FilterBarButton"
-            android:text="@string/filter_button_title" />
+            android:text="@string/many_filter_button_title" />
 
         <Space
             android:layout_weight="1"

--- a/app/src/main/res/layout/filter_button_bar.xml
+++ b/app/src/main/res/layout/filter_button_bar.xml
@@ -21,7 +21,7 @@
             android:background="@drawable/toggle_button_toolbar_unchecked"
             android:drawableStart="@drawable/ic_filter_list_white_24dp"
             style="@style/FilterBarButton"
-            android:text="@string/many_filter_button_title" />
+            android:text="@{@plurals/filter_button_title(filter.count())}" />
 
         <Space
             android:layout_weight="1"

--- a/app/src/main/res/layout/filter_modal.xml
+++ b/app/src/main/res/layout/filter_modal.xml
@@ -33,7 +33,7 @@
 
             <TextView
                 android:textColor="@color/color_white"
-                android:text="@string/filter_button_title"
+                android:text="@string/many_filter_button_title"
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:textAllCaps="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,12 @@
     <!-- filtering -->
     <string name="reset_button">Reset</string>
     <string name="done_button">Done</string>
-    <string name="filter_button_title">Filters</string>
+    <string name="single_filter_button_title">Filter</string>
+    <string name="many_filter_button_title">Filters</string>
+    <plurals name="filter_button_title">
+        <item quantity="one">@string/single_filter_button_title</item>
+        <item quantity="other">@string/many_filter_button_title</item>
+    </plurals>
     <string name="accessible_filter_button_title">Wheelchair accessible</string>
 
     <string name="watershed_alliance_label">Watershed Alliance</string>
@@ -38,8 +43,6 @@
     <!-- place details -->
     <plurals name="place_upcoming_activities_count">
         <item quantity="one">%d upcoming event</item>
-        <item quantity="many">%d upcoming events</item>
-        <item quantity="few">%d upcoming events</item>
         <item quantity="other">%d upcoming events</item>
     </plurals>
 


### PR DESCRIPTION
Also removes unused "many" and "few" options for `place_upcoming_activities_count` - according to the documentation, they will never be used for English language strings.

![screenshot_1528312978](https://user-images.githubusercontent.com/4432106/41060447-be053ea8-699d-11e8-8597-d1964d344696.png)
![screenshot_1528312974](https://user-images.githubusercontent.com/4432106/41060448-be117394-699d-11e8-9cf6-ce0c32c1864e.png)
![screenshot_1528312969](https://user-images.githubusercontent.com/4432106/41060449-be1f4726-699d-11e8-8092-88e025c1f26f.png)


Closes #48