### PR TITLE
Set up Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # API keys
+!examples/*
+crashlytics.properties
 app/**/api_keys.xml
 app/**/google_maps_api.xml
 app/src/debug/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Copy API keys file for debug and release builds:
 Edit each to set the Android Maps key for both build flavors. See the comments in the example file for directions on how to create the keys.
 
 Also edit to set the server API key for posting user flags.
+
+Copy the example file for the Crashlytics configuration and set the API key.
+ - `cp example/crashlytics.properties crashlytics.properties`
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,19 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.fabric.io/public' }
+    }
+
+    dependencies {
+        classpath 'io.fabric.tools:gradle:1.+'
+    }
+}
 apply plugin: 'com.android.application'
+
+repositories {
+    maven { url 'https://maven.fabric.io/public' }
+}
+
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 27
@@ -34,6 +49,9 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    // Firebase
+    implementation 'com.google.firebase:firebase-core:16.0.0'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.3'
     // Architecture Components
     def archComponentsVersion = '1.1.1'
     def roomVersion = '1.1.0'
@@ -88,3 +106,5 @@ dependencies {
     // Test helpers for Room
     testImplementation "android.arch.persistence.room:testing:$roomVersion"
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -61,7 +61,7 @@
 # removes such information by default, so configure it to keep all of it.
 -keepattributes Signature
 
-# For using GSON @Expose annotation
+# For using GSON @Expose annotation and for Fabric
 -keepattributes *Annotation*
 
 # Gson specific classes
@@ -76,3 +76,8 @@
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
+
+# Fabric
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception
+-keepresourcexmlelements manifest/application/meta-data@name=io.fabric.ApiKey

--- a/app/src/main/java/com/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/com/gophillygo/app/GoPhillyGoApp.java
@@ -5,8 +5,10 @@ import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.gophillygo.app.di.AppInjector;
 
+import io.fabric.sdk.android.Fabric;
 import javax.inject.Inject;
 
 import dagger.android.AndroidInjector;
@@ -35,6 +37,7 @@ public class GoPhillyGoApp extends Application implements HasActivityInjector, H
     @Override
     public void onCreate() {
         super.onCreate();
+        Fabric.with(this, new Crashlytics());
         if (BuildConfig.DEBUG) {
             Log.d(LOG_LABEL, "Running in debug mode");
         }

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.crashlytics.android.Crashlytics;
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.models.Attraction;
 import com.gophillygo.app.data.models.AttractionInfo;
@@ -22,6 +23,8 @@ import com.gophillygo.app.data.models.EventInfo;
 import com.gophillygo.app.tasks.AddGeofencesBroadcastReceiver;
 import com.gophillygo.app.tasks.RemoveGeofenceWorker;
 import com.synnapps.carouselview.CarouselView;
+
+import io.fabric.sdk.android.Fabric;
 
 abstract class AttractionDetailActivity extends AppCompatActivity {
     protected static final int COLLAPSED_LINE_COUNT = 4;
@@ -56,6 +59,7 @@ abstract class AttractionDetailActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Fabric.with(this, new Crashlytics());
         toggleClickListener = v -> {
             // click handler for toggling expanding/collapsing description card
             TextView descriptionView = findViewById(R.id.detail_description_text);

--- a/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.AttractionInfo;
 import com.gophillygo.app.data.models.Destination;
@@ -29,6 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import io.fabric.sdk.android.Fabric;
 
 /**
  * Base activity that requests last known location and destination data when opened;
@@ -101,6 +104,8 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Fabric.with(this, new Crashlytics());
+
         fetchLastLocationOrUseDefault();
 
         viewModel = ViewModelProviders.of(this, viewModelFactory)

--- a/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/HomeActivity.java
@@ -12,11 +12,8 @@ import android.widget.GridView;
 import com.gophillygo.app.CarouselViewListener;
 import com.gophillygo.app.R;
 import com.gophillygo.app.adapters.PlaceCategoryGridAdapter;
-import com.gophillygo.app.data.models.AttractionFlag;
 import com.gophillygo.app.data.models.Destination;
 import com.synnapps.carouselview.CarouselView;
-
-import java.util.List;
 
 
 public class HomeActivity extends BaseAttractionActivity {

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,18 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        // This belongs in the project-level build file, per
+        // https://firebase.google.com/docs/crashlytics/get-started
+        classpath 'io.fabric.tools:gradle:1.25.4'
+        classpath 'com.google.gms:google-services:4.0.1'
     }
 }
 
@@ -18,6 +24,8 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://maven.google.com/' }
+        maven { url 'https://maven.fabric.io/public' }
     }
 }
 

--- a/example/crashlytics.properties
+++ b/example/crashlytics.properties
@@ -1,0 +1,2 @@
+apiKey=CRASHLYTICS_API_KEY
+


### PR DESCRIPTION
## Overview

Add Crashlytics to the project to gather crash logs, support logging analytics events (none set up yet), and to manage beta distribution.

## Demo

The Fabric dashboard:

![fabric_crashlytics_ui](https://user-images.githubusercontent.com/960264/41313105-01ee4bb0-6e57-11e8-92f8-a3e92cc74699.png)

The Android Studio Fabric plugin:

![fabric_android_studio_plugin](https://user-images.githubusercontent.com/960264/41313122-0b3069b0-6e57-11e8-807b-83459cd7453f.png)

Log of a crash event being sent:

![crashlytics_console_log](https://user-images.githubusercontent.com/960264/41313131-17cefa10-6e57-11e8-80ca-50672059b25b.png)

## Notes

The API key cannot be set via string resource, which is why the extra file was added instead. See [this discussion](https://stackoverflow.com/questions/25700680/crashlytics-found-an-invalid-api-key).

## Testing

 - Set up the new `crashlytics.properties` file
 - Run app
 - Cause app to crash (trying to 'like' an event on the details page works)
 - Should get a console log
 - Should see event in Fabric/Firebase consoles

Closes #58 
