### PR TITLE
Handle rotation on map activity

### DIFF
--- a/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
@@ -56,6 +56,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     private static final int DEFAULT_ZOOM = 12;
     private static final int ATTRACTION_ZOOM = 14;
     private static final float DEFAULT_OPACITY = 1f, FILTERED_OPACITY = 0.5f;
+    private static final String LOCATION_SET_KEY = "locationSet";
     private static final String LOG_LABEL = "MapsActivity";
     public static final String X = "x";
     public static final String Y = "y";
@@ -84,10 +85,19 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(mapId);
+        if (savedInstanceState != null) {
+            locationSet = savedInstanceState.getBoolean(LOCATION_SET_KEY);
+        }
         mapFragment.getMapAsync(this);
 
         markerIcon = vectorToBitmap(R.drawable.ic_map_marker);
         selectedMarkerIcon = vectorToBitmap(R.drawable.ic_selected_map_marker);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(LOCATION_SET_KEY, locationSet);
+        super.onSaveInstanceState(outState);
     }
 
     /**

--- a/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
@@ -93,8 +93,8 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     /**
      * Manipulates the map once available.
      * This callback is triggered when the map is ready to be used.
-     * This is where we can add markers or lines, add listeners or move the camera. In this case,
-     * we just add a marker near Sydney, Australia.
+     * This is where we can add markers or lines, add listeners or move the camera.
+     *
      * If Google Play services is not installed on the device, the user will be prompted to install
      * it inside the SupportMapFragment. This method will only be triggered once the user has
      * installed Google Play services and returned to the app.
@@ -103,6 +103,9 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     public void onMapReady(GoogleMap googleMap) {
         this.googleMap = googleMap;
         googleMap.getUiSettings().setMapToolbarEnabled(false);
+        googleMap.setOnMarkerClickListener(this::selectMarker);
+
+        loadMarkers();
         panToLocation();
     }
 
@@ -168,8 +171,6 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
 
         loadMarkers();
         reloadSelectedAttraction();
-
-        googleMap.setOnMarkerClickListener(this::selectMarker);
     }
 
     public void openDetail(Attraction attraction) {
@@ -189,6 +190,10 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
 
     @SuppressLint("UseSparseArrays")
     private void loadMarkers() {
+        if (googleMap == null || attractions == null) {
+            return;
+        }
+
         if (markers == null) {
             markers = new HashMap<>(attractions.size());
             for (T attractionInfo : attractions.values()) {

--- a/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
@@ -56,7 +56,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     private static final int DEFAULT_ZOOM = 12;
     private static final int ATTRACTION_ZOOM = 14;
     private static final float DEFAULT_OPACITY = 1f, FILTERED_OPACITY = 0.5f;
-    private static final String LOCATION_SET_KEY = "locationSet";
+    private static final String LOCATION_SET_KEY = "location_set";
     private static final String LOG_LABEL = "MapsActivity";
 
     public static final String X = "x";
@@ -64,7 +64,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     public static final String ATTRACTION_ID = "id";
 
     private Map<Integer, Marker> markers;
-    private Integer selectedAttractionId = null;
+    private int selectedAttractionId = -1;
     private boolean locationSet = false;
     protected GoogleMap googleMap;
     protected Map<Integer, T> attractions;
@@ -86,7 +86,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(mapId);
-        if (savedInstanceState != null) {
+        if (savedInstanceState != null && savedInstanceState.containsKey(LOCATION_SET_KEY)) {
             locationSet = savedInstanceState.getBoolean(LOCATION_SET_KEY);
         }
         if (savedInstanceState != null && savedInstanceState.containsKey(ATTRACTION_ID)) {
@@ -103,9 +103,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putBoolean(LOCATION_SET_KEY, locationSet);
-        if (selectedAttractionId != null) {
-            outState.putInt(ATTRACTION_ID, selectedAttractionId);
-        }
+        outState.putInt(ATTRACTION_ID, selectedAttractionId);
         super.onSaveInstanceState(outState);
     }
 
@@ -230,7 +228,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
                     markers.put(id, marker);
                 }
             }
-            if (selectedAttractionId != null) {
+            if (selectedAttractionId != -1) {
                 selectMarker(markers.get(selectedAttractionId));
             }
         } else {
@@ -248,7 +246,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     }
 
     private void reloadSelectedAttraction() {
-        if (selectedAttractionId == null) { return; }
+        if (selectedAttractionId == -1) { return; }
 
         T attractionInfo = selectedAttractionInfo();
         popupBinding.setAttractionInfo(attractionInfo);
@@ -260,10 +258,11 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     }
 
     private boolean selectMarker(Marker marker) {
-        if (selectedAttractionId != null) {
+        if (selectedAttractionId != -1) {
             Marker prevSelectedMarker = markers.get(selectedAttractionId);
             prevSelectedMarker.setIcon(markerIcon);
         }
+        //noinspection ConstantConditions
         selectedAttractionId = (Integer) marker.getTag();
         marker.setIcon(selectedMarkerIcon);
         showPopup();


### PR DESCRIPTION
## Overview

Handles rotation events on the map activities by saving/restoring a few key properties (the selected attraction, whether we had already set the map location).

## Notes
I opted not to save/restore the current filters since that should be taken care of by #80 

Closes #72 