### PR TITLE
Fancy notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # API keys
 !examples/*
 crashlytics.properties
+fabric.properties
 app/**/api_keys.xml
 app/**/google_maps_api.xml
 app/src/debug/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ These can be found under the [organization settings](https://www.fabric.io/setti
 
  - `cp example/fabric.properties app/fabric.properties`
 
+
+Configure Firebase for the crash reporting plugin to function. The Firebase configuration file can be found under the [Firebase console](https://console.firebase.google.com). Copy the `google-services.json` Firebase configuration file to the `app` directory.
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Edit each to set the Android Maps key for both build flavors. See the comments i
 
 Also edit to set the server API key for posting user flags.
 
-Copy the example file for the Crashlytics configuration and set the API key.
- - `cp example/crashlytics.properties crashlytics.properties`
+Copy the example file for the Crashlytics/Fabric configuration and set the API key and secret.
+These can be found under the [organization settings](https://www.fabric.io/settings/organizations).
+
+ - `cp example/fabric.properties app/fabric.properties`
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "com.gophillygo.app"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
         javaCompileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,11 +50,11 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Firebase
-    implementation 'com.google.firebase:firebase-core:16.0.0'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.3'
+    implementation 'com.google.firebase:firebase-core:16.0.1'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.4'
     // Architecture Components
     def archComponentsVersion = '1.1.1'
-    def roomVersion = '1.1.0'
+    def roomVersion = '1.1.1'
     // ViewModel and LiveData
     implementation "android.arch.lifecycle:extensions:$archComponentsVersion"
     // Java8 support for Lifecycles
@@ -68,13 +68,13 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:cardview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     // Android Play services libraries
     def playServicesVersion = '15.0.1'
     implementation "com.google.android.gms:play-services-location:$playServicesVersion"
     implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
     // Android WorkManager
-    implementation "android.arch.work:work-runtime:1.0.0-alpha02"
+    implementation "android.arch.work:work-runtime:1.0.0-alpha03"
     // Carousel
     implementation 'com.github.flibbertigibbet:carouselview:1.0.5'
     // Badges

--- a/app/schemas/com.gophillygo.app.data.GpgDatabase/12.json
+++ b/app/schemas/com.gophillygo.app.data.GpgDatabase/12.json
@@ -1,0 +1,530 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "5cbe98c663ba7f4df4514cb325906a9a",
+    "entities": [
+      {
+        "tableName": "AttractionFlag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`attraction_id` INTEGER NOT NULL, `is_event` INTEGER NOT NULL, `option` INTEGER, PRIMARY KEY(`attraction_id`, `is_event`))",
+        "fields": [
+          {
+            "fieldPath": "attractionID",
+            "columnName": "attraction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "option",
+            "columnName": "option",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "attraction_id",
+            "is_event"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_AttractionFlag_is_event_option",
+            "unique": false,
+            "columnNames": [
+              "is_event",
+              "option"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_is_event_option` ON `${TABLE_NAME}` (`is_event`, `option`)"
+          },
+          {
+            "name": "index_AttractionFlag_attraction_id",
+            "unique": false,
+            "columnNames": [
+              "attraction_id"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_attraction_id` ON `${TABLE_NAME}` (`attraction_id`)"
+          },
+          {
+            "name": "index_AttractionFlag_is_event",
+            "unique": false,
+            "columnNames": [
+              "is_event"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_is_event` ON `${TABLE_NAME}` (`is_event`)"
+          },
+          {
+            "name": "index_AttractionFlag_option",
+            "unique": false,
+            "columnNames": [
+              "option"
+            ],
+            "createSql": "CREATE  INDEX `index_AttractionFlag_option` ON `${TABLE_NAME}` (`option`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Destination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT, `state` TEXT, `address` TEXT, `categories` TEXT, `watershed_alliance` INTEGER NOT NULL, `zipcode` TEXT, `distance` REAL NOT NULL, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, `nature` INTEGER, `exercise` INTEGER, `educational` INTEGER, `x` REAL, `y` REAL, `street_address` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watershedAlliance",
+            "columnName": "watershed_alliance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipCode",
+            "columnName": "zipcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryFlags.nature",
+            "columnName": "nature",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categoryFlags.exercise",
+            "columnName": "exercise",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categoryFlags.educational",
+            "columnName": "educational",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.x",
+            "columnName": "x",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.y",
+            "columnName": "y",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attributes.streetAddress",
+            "columnName": "street_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Destination_educational",
+            "unique": false,
+            "columnNames": [
+              "educational"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_educational` ON `${TABLE_NAME}` (`educational`)"
+          },
+          {
+            "name": "index_Destination_nature",
+            "unique": false,
+            "columnNames": [
+              "nature"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_nature` ON `${TABLE_NAME}` (`nature`)"
+          },
+          {
+            "name": "index_Destination_exercise",
+            "unique": false,
+            "columnNames": [
+              "exercise"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_exercise` ON `${TABLE_NAME}` (`exercise`)"
+          },
+          {
+            "name": "index_Destination_watershed_alliance",
+            "unique": false,
+            "columnNames": [
+              "watershed_alliance"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_watershed_alliance` ON `${TABLE_NAME}` (`watershed_alliance`)"
+          },
+          {
+            "name": "index_Destination_distance",
+            "unique": false,
+            "columnNames": [
+              "distance"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_distance` ON `${TABLE_NAME}` (`distance`)"
+          },
+          {
+            "name": "index_Destination_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Destination_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Destination_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Destination_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Destination_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Destination_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `start_date` TEXT, `end_date` TEXT, `id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Event_destination",
+            "unique": false,
+            "columnNames": [
+              "destination"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_destination` ON `${TABLE_NAME}` (`destination`)"
+          },
+          {
+            "name": "index_Event_start_date",
+            "unique": false,
+            "columnNames": [
+              "start_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_start_date` ON `${TABLE_NAME}` (`start_date`)"
+          },
+          {
+            "name": "index_Event_end_date",
+            "unique": false,
+            "columnNames": [
+              "end_date"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_end_date` ON `${TABLE_NAME}` (`end_date`)"
+          },
+          {
+            "name": "index_Event_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Event_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Event_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Event_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Event_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE  INDEX `index_Event_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Destination",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "destination"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"5cbe98c663ba7f4df4514cb325906a9a\")"
+    ]
+  }
+}

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -26,13 +27,17 @@ import com.synnapps.carouselview.CarouselView;
 
 import io.fabric.sdk.android.Fabric;
 
-abstract class AttractionDetailActivity extends AppCompatActivity {
+public abstract class AttractionDetailActivity extends AppCompatActivity {
+
+    public static final String NOTIFICATION_ID_KEY = "launching_notification_id";
+    public static final String GEOFENCE_ID_KEY = "launching_geofence_id";
+
     protected static final int COLLAPSED_LINE_COUNT = 4;
     protected static final int EXPANDED_MAX_LINES = 50;
     private static final String LOG_LABEL = "AttractionDetail";
 
     protected DestinationInfo destinationInfo;
-    protected View.OnClickListener toggleClickListener;
+    public View.OnClickListener toggleClickListener;
 
     protected abstract Class getMapActivity();
     protected abstract int getAttractionId();
@@ -76,13 +81,26 @@ abstract class AttractionDetailActivity extends AppCompatActivity {
                 descriptionView.setEllipsize(TextUtils.TruncateAt.END);
                 // disable clicking links to also disable scrolling
                 descriptionView.setMovementMethod(null);
-                // must reset click listener after unsetting movement method
+                // must reset click listener after un-setting movement method
                 v.setOnClickListener(toggleClickListener);
                 // set text again, to make ellipsize run
                 descriptionView.setText(descriptionView.getText());
                 view.setText(R.string.detail_description_expand);
             }
         };
+
+        // cancel launching notification, if any
+        if (getIntent().hasExtra(NOTIFICATION_ID_KEY)) {
+            String notificationId = getIntent().getStringExtra(NOTIFICATION_ID_KEY);
+            int geofenceId = getIntent().getIntExtra(GEOFENCE_ID_KEY, -1);
+            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
+
+            if (notificationId != null && !notificationId.isEmpty() && geofenceId > -1) {
+                notificationManager.cancel(notificationId, geofenceId);
+                Log.d(LOG_LABEL, "Closing notification after launching detail view");
+            }
+        }
+
     }
 
     // open map when user clicks map button

--- a/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/AttractionDetailActivity.java
@@ -23,6 +23,7 @@ import com.gophillygo.app.data.models.DestinationLocation;
 import com.gophillygo.app.data.models.EventInfo;
 import com.gophillygo.app.tasks.AddGeofencesBroadcastReceiver;
 import com.gophillygo.app.tasks.RemoveGeofenceWorker;
+import com.gophillygo.app.utils.UserUuidUtils;
 import com.synnapps.carouselview.CarouselView;
 
 import io.fabric.sdk.android.Fabric;
@@ -37,6 +38,7 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
     private static final String LOG_LABEL = "AttractionDetail";
 
     protected DestinationInfo destinationInfo;
+    protected String userUuid;
     public View.OnClickListener toggleClickListener;
 
     protected abstract Class getMapActivity();
@@ -65,6 +67,9 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Fabric.with(this, new Crashlytics());
+        // Get or create unique, random UUID for app install for posting user flags
+        userUuid = UserUuidUtils.getUserUuid(getApplicationContext());
+        Crashlytics.setUserIdentifier(userUuid);
         toggleClickListener = v -> {
             // click handler for toggling expanding/collapsing description card
             TextView descriptionView = findViewById(R.id.detail_description_text);

--- a/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/BaseAttractionActivity.java
@@ -134,6 +134,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
 
             // Get or create unique, random UUID for app install for posting user flags
             userUuid = UserUuidUtils.getUserUuid(getApplicationContext());
+            Crashlytics.setUserIdentifier(userUuid);
         });
     }
 

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -14,7 +14,6 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import com.crashlytics.android.Crashlytics;
@@ -28,7 +27,6 @@ import com.gophillygo.app.data.models.EventInfo;
 import com.gophillygo.app.databinding.ActivityEventDetailBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 import com.gophillygo.app.utils.FlagMenuUtils;
-import com.gophillygo.app.utils.UserUuidUtils;
 import com.synnapps.carouselview.CarouselView;
 
 import java.text.DateFormat;
@@ -55,7 +53,6 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
     private long eventId = -1;
     private EventInfo eventInfo;
-    private String userUuid;
 
     private ActivityEventDetailBinding binding;
 
@@ -92,9 +89,6 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
         carouselView = findViewById(R.id.event_detail_carousel);
         carouselView.setIndicatorGravity(Gravity.CENTER_HORIZONTAL|Gravity.BOTTOM);
-
-        // Get or create unique, random UUID for app install for posting user flags
-        userUuid = UserUuidUtils.getUserUuid(getApplicationContext());
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
         destinationViewModel = ViewModelProviders.of(this, viewModelFactory).get(DestinationViewModel.class);

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -138,6 +138,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
             // set up data binding object
             binding.setEvent(eventInfo.getEvent());
             binding.setEventInfo(eventInfo);
+            binding.eventDetailDescriptionCard.detailDescriptionToggle.setOnClickListener(toggleClickListener);
             displayEvent();
         });
     }
@@ -193,9 +194,6 @@ public class EventDetailActivity extends AttractionDetailActivity {
     @SuppressLint({"RestrictedApi", "RtlHardcoded"})
     private void displayEvent() {
         setupCarousel(carouselView, eventInfo.getEvent());
-
-        TextView descriptionToggle = findViewById(R.id.detail_description_toggle);
-        descriptionToggle.setOnClickListener(toggleClickListener);
 
         // show popover for flag options (been, want to go, etc.)
         CardView flagOptionsCard = findViewById(R.id.event_detail_flag_options_card);

--- a/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/EventDetailActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.crashlytics.android.Crashlytics;
+import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.EventViewModel;
@@ -208,6 +209,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
         viewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
         Boolean settingGeofence = eventInfo.getFlag().getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
         addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
+        binding.notifyPropertyChanged(BR.destinationInfo);
     }
 
     public String getEventTimeString() {

--- a/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/MapsActivity.java
@@ -29,26 +29,14 @@ import com.gophillygo.app.R;
 import com.gophillygo.app.data.models.Attraction;
 import com.gophillygo.app.data.models.AttractionFlag;
 import com.gophillygo.app.data.models.AttractionInfo;
-import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationLocation;
-import com.gophillygo.app.data.models.EventInfo;
 import com.gophillygo.app.databinding.MapPopupCardBinding;
-import com.gophillygo.app.tasks.AddGeofenceWorker;
-import com.gophillygo.app.tasks.AddGeofencesBroadcastReceiver;
-import com.gophillygo.app.tasks.RemoveGeofenceWorker;
 import com.gophillygo.app.utils.FlagMenuUtils;
 import com.gophillygo.app.utils.GpgLocationUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
-
-import androidx.work.Data;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
-
-import static com.gophillygo.app.tasks.AddGeofencesBroadcastReceiver.ADD_GEOFENCE_TAG;
 
 public abstract class MapsActivity<T extends AttractionInfo> extends FilterableListActivity
         implements OnMapReadyCallback {

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -6,12 +6,12 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.v7.widget.PopupMenu;
-import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 
 import com.crashlytics.android.Crashlytics;
+import com.gophillygo.app.BR;
 import com.gophillygo.app.R;
 import com.gophillygo.app.data.DestinationViewModel;
 import com.gophillygo.app.data.models.AttractionFlag;
@@ -30,8 +30,6 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
     private static final String LOG_LABEL = "PlaceDetail";
 
     private long placeId = -1;
-    private String userUuid;
-
     private ActivityPlaceDetailBinding binding;
 
     @SuppressWarnings("WeakerAccess")
@@ -125,6 +123,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
         viewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
         Boolean settingGeofence = itemId  == AttractionFlag.Option.WantToGo.code;
         addOrRemoveGeofence(destinationInfo, haveExistingGeofence, settingGeofence);
+        binding.notifyPropertyChanged(BR.destinationInfo);
     }
 
     // TODO: go to list of events, filtered to this destination?

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -96,6 +96,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
             // set up data binding object
             binding.setDestination(destinationInfo.getDestination());
             binding.setDestinationInfo(destinationInfo);
+            binding.placeDetailDescriptionCard.detailDescriptionToggle.setOnClickListener(toggleClickListener);
             displayDestination();
         });
     }

--- a/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/com/gophillygo/app/activities/PlaceDetailActivity.java
@@ -19,7 +19,6 @@ import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.databinding.ActivityPlaceDetailBinding;
 import com.gophillygo.app.di.GpgViewModelFactory;
 import com.gophillygo.app.utils.FlagMenuUtils;
-import com.gophillygo.app.utils.UserUuidUtils;
 
 import javax.inject.Inject;
 
@@ -65,9 +64,6 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
         binding.placeDetailCarousel.setIndicatorGravity(Gravity.CENTER_HORIZONTAL|Gravity.BOTTOM);
         binding.placeDetailCarousel.setImageClickListener(position ->
                 Log.d(LOG_LABEL, "Clicked item: "+ position));
-
-        // Get or create unique, random UUID for app install for posting user flags
-        userUuid = UserUuidUtils.getUserUuid(getApplicationContext());
 
         viewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(DestinationViewModel.class);

--- a/app/src/main/java/com/gophillygo/app/data/DestinationViewModel.java
+++ b/app/src/main/java/com/gophillygo/app/data/DestinationViewModel.java
@@ -2,8 +2,6 @@ package com.gophillygo.app.data;
 
 import android.arch.lifecycle.LiveData;
 
-import com.gophillygo.app.data.models.AttractionFlag;
-import com.gophillygo.app.data.models.CategoryAttraction;
 import com.gophillygo.app.data.models.Destination;
 import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.data.networkresource.Resource;

--- a/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -54,7 +54,7 @@ public class AddGeofenceWorker extends Worker {
 
     @NonNull
     @Override
-    public WorkerResult doWork() {
+    public Result doWork() {
         Log.d(LOG_LABEL, "Starting add geofence worker");
 
         Context context = getApplicationContext();
@@ -83,7 +83,7 @@ public class AddGeofenceWorker extends Worker {
             String message = "Data missing for geofences to add";
             Crashlytics.log(message);
             Log.e(LOG_LABEL, message);
-            return  WorkerResult.FAILURE;
+            return Result.FAILURE;
         }
 
         if (latitudes.length != longitudes.length || latitudes.length != geofenceLabels.length ||
@@ -91,7 +91,7 @@ public class AddGeofenceWorker extends Worker {
             String message = "Location data for geofences to add should be arrays of the same length.";
             Crashlytics.log(message);
             Log.e(LOG_LABEL, message);
-            return WorkerResult.FAILURE;
+            return Result.FAILURE;
         }
 
         for (int i = 0; i < latitudes.length; i++) {
@@ -117,22 +117,21 @@ public class AddGeofenceWorker extends Worker {
 
         try {
             geofencingClient.addGeofences(builder.build(), pendingIntent);
-            return WorkerResult.SUCCESS;
+            return Result.SUCCESS;
         } catch (SecurityException ex) {
             String message = "Missing permissions to add geofences";
             Log.e(LOG_LABEL, message);
             Crashlytics.log(message);
             Crashlytics.logException(ex);
             ex.printStackTrace();
-            return WorkerResult.FAILURE;
+            return Result.FAILURE;
         } catch (Exception ex) {
             String message = "Failed to add geofences";
             Log.e(LOG_LABEL, message);
             Crashlytics.log(message);
             ex.printStackTrace();
             Crashlytics.logException(ex);
-            return WorkerResult.FAILURE;
+            return Result.FAILURE;
         }
-
     }
 }

--- a/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -114,12 +114,18 @@ public class AddGeofenceWorker extends Worker {
             geofencingClient.addGeofences(builder.build(), pendingIntent);
             return WorkerResult.SUCCESS;
         } catch (SecurityException ex) {
-            Log.e(LOG_LABEL, "Missing permissions to add geofences");
+            String message = "Missing permissions to add geofences";
+            Log.e(LOG_LABEL, message);
+            Crashlytics.log(message);
+            Crashlytics.logException(ex);
             ex.printStackTrace();
             return WorkerResult.FAILURE;
         } catch (Exception ex) {
-            Log.e(LOG_LABEL, "Failed to add geofences");
+            String message = "Failed to add geofences";
+            Log.e(LOG_LABEL, message);
+            Crashlytics.log(message);
             ex.printStackTrace();
+            Crashlytics.logException(ex);
             return WorkerResult.FAILURE;
         }
 

--- a/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.GeofencingRequest;
@@ -35,10 +36,10 @@ public class AddGeofenceWorker extends Worker {
     // Send alert roughly after device has been in geofence for this long.
     // When we are using the DWELL filter, this is about when we will receive notifications.
     // In development (DEBUG build), use no delay.
-    private static final int GEOFENCE_LOITERING_DELAY = BuildConfig.DEBUG ? 0 : 300000; // 5 minutes
+    private static final int GEOFENCE_LOITERING_DELAY = BuildConfig.DEBUG ? 60000 : 180000; // 1 or 3 minutes
 
     // Set responsiveness high to save battery
-    private static final int GEOFENCE_RESPONSIVENESS = BuildConfig.DEBUG ? 0 : 300000; // 5 minutes
+    private static final int GEOFENCE_RESPONSIVENESS = BuildConfig.DEBUG ? 180000 : 300000; // 3 or 5 minutes
 
     private static final String LOG_LABEL = "AddGeofenceWorker";
     private static final int TRANSITION_BROADCAST_REQUEST_CODE = 42;
@@ -76,13 +77,17 @@ public class AddGeofenceWorker extends Worker {
             geofenceLabels = data.getStringArray(GEOFENCE_LABELS_KEY);
             geofenceNames = data.getStringArray(GEOFENCE_NAMES_KEY);
         } else {
-            Log.e(LOG_LABEL, "Data missing for geofences to add");
+            String message = "Data missing for geofences to add";
+            Crashlytics.log(message);
+            Log.e(LOG_LABEL, message);
             return  WorkerResult.FAILURE;
         }
 
         if (latitudes.length != longitudes.length || latitudes.length != geofenceLabels.length ||
                 latitudes.length != geofenceNames.length) {
-            Log.e(LOG_LABEL, "Location data for geofences to add should be arrays of the same length.");
+            String message = "Location data for geofences to add should be arrays of the same length.";
+            Crashlytics.log(message);
+            Log.e(LOG_LABEL, message);
             return WorkerResult.FAILURE;
         }
 

--- a/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -49,6 +49,9 @@ public class AddGeofenceWorker extends Worker {
     public static final String GEOFENCE_LABELS_KEY = "geofence_labels";
     public static final String GEOFENCE_NAMES_KEY = "geofence_names";
 
+    // event identifiers used for custom Crashlytics event to note a geofence was added
+    private static final String ADD_GEOFENCE_EVENT = "add_geofence";
+
     @NonNull
     @Override
     public WorkerResult doWork() {
@@ -101,6 +104,8 @@ public class AddGeofenceWorker extends Worker {
                     .setNotificationResponsiveness(GEOFENCE_RESPONSIVENESS)
                     .setTransitionTypes(GEOFENCE_ENTER_TRIGGER | Geofence.GEOFENCE_TRANSITION_EXIT)
                     .build());
+
+            Crashlytics.log(ADD_GEOFENCE_EVENT);
         }
 
         // Location access permissions prompting is handled by `GpgLocationUtils`.

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
@@ -26,6 +26,9 @@ import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
 import dagger.android.AndroidInjection;
 
+import static com.gophillygo.app.tasks.GeofenceTransitionWorker.DESTINATION_PREFIX;
+import static com.gophillygo.app.tasks.GeofenceTransitionWorker.EVENT_PREFIX;
+
 public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
 
     @Inject
@@ -91,7 +94,7 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                             // Geofence string ID is "d" for destination or "e" for event, followed by the
                             // destination or event integer ID.
                             int geofenceId = Integer.valueOf(fenceId.substring(1));
-                            boolean isEvent = fenceId.startsWith("e");
+                            boolean isEvent = fenceId.startsWith(EVENT_PREFIX);
 
                             // query for each event or destination synchronously from the database
                             if (isEvent) {
@@ -100,7 +103,7 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                                     Log.e(LOG_LABEL, "Could not find event for geofence " + geofenceId);
                                     continue;
                                 }
-                                labels[i] = "e" + String.valueOf(eventInfo.getAttraction().getId());
+                                labels[i] = EVENT_PREFIX + String.valueOf(eventInfo.getAttraction().getId());
                                 names[i] = eventInfo.getEvent().getName();
                                 DestinationLocation location = eventInfo.getLocation();
                                 latitudes[i] = location.getY();
@@ -110,7 +113,7 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                                 if (destination == null) {
                                     Log.e(LOG_LABEL, "Could not find destination for geofence " + geofenceId);
                                 }
-                                labels[i] = "d" + String.valueOf(destination.getId());
+                                labels[i] = DESTINATION_PREFIX + String.valueOf(destination.getId());
                                 names[i] = destination.getName();
                                 DestinationLocation location = destination.getLocation();
                                 latitudes[i] = location.getY();

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
 import com.gophillygo.app.data.DestinationDao;
@@ -107,15 +108,18 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                                 }
                                 labels[i] = EVENT_PREFIX + String.valueOf(eventInfo.getAttraction().getId());
                                 names[i] = eventInfo.getEvent().getName();
-                                images[i] = eventInfo.getEvent().getImage();
+                                images[i] = eventInfo.getEvent().getWideImage();
                             } else {
                                 Destination destination = destinationDao.getDestinationInBackground(geofenceId);
                                 if (destination == null) {
-                                    Log.e(LOG_LABEL, "Could not find destination for geofence " + geofenceId);
+                                    String message = "Could not find destination for geofence " + geofenceId;
+                                    Log.e(LOG_LABEL, message);
+                                    Crashlytics.log(message);
+                                } else {
+                                    labels[i] = DESTINATION_PREFIX + String.valueOf(destination.getId());
+                                    names[i] = destination.getName();
+                                    images[i] = destination.getWideImage();
                                 }
-                                labels[i] = DESTINATION_PREFIX + String.valueOf(destination.getId());
-                                names[i] = destination.getName();
-                                images[i] = destination.getImage();
                             }
                         }
 

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -37,6 +37,7 @@ public class GeofenceTransitionWorker extends Worker {
     public static final String EVENT_PREFIX = "e";
 
     private static final String CHANNEL_ID = "gophillygo-nearby-places";
+    private static final String GROUP_ID = "gophillygo-entered-geofence";
 
     private static final String LOG_LABEL = "GeofenceTransition";
 
@@ -82,8 +83,6 @@ public class GeofenceTransitionWorker extends Worker {
                 // Need a unique int we can find later, for the notification
                 String geofenceLabel = geofences[i];
                 String placeName = geofencePlaceNames[i];
-                double latitude = latitudes[i];
-                double longitude = longitudes[i];
 
                 // Geofence string ID is "d" for destination or "e" for event, followed by the
                 // destination or event integer ID.
@@ -124,13 +123,18 @@ public class GeofenceTransitionWorker extends Worker {
                                 .setContentTitle(placeName)
                                 .setContentText(context.getString(R.string.place_nearby_notification, placeName))
                                 .setContentIntent(resultPendingIntent)
-                                .setAutoCancel(true) // close notifcation when tapped
-                                .setPriority(NotificationCompat.PRIORITY_HIGH);
+                                .setAutoCancel(true) // close notification when tapped
+                                .setGroup(GROUP_ID)
+                                // alert for all notifications
+                                .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_ALL)
+                                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                                .setStyle(new NotificationCompat.InboxStyle().addLine(placeName));
 
                         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
 
                         // The pair of notification string tag and int must be unique for the app
                         notificationManager.notify(notificationTag, geofenceId, mBuilder.build());
+
                     });
 
                 } else {

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -178,7 +178,7 @@ public class GeofenceTransitionWorker extends Worker {
                                 .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
                                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                                 .addAction(R.drawable.ic_beenhere_blue_24dp,
-                                        context.getString(R.string.place_been_option),
+                                        context.getString(R.string.place_nearby_been_button),
                                         beenPendingIntent)
                                 .setGroupSummary(true);
 

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -61,7 +61,7 @@ public class GeofenceTransitionWorker extends Worker {
     @NonNull
     @Override
     @SuppressLint("StringFormatInvalid")
-    public WorkerResult doWork() {
+    public Result doWork() {
         Log.d(LOG_LABEL, "Starting geofence transition worker");
 
         // Geofence event data passed along as primitives
@@ -89,7 +89,7 @@ public class GeofenceTransitionWorker extends Worker {
         Log.d(LOG_LABEL, "Have " + geofencesCount + " geofence transitions to process");
         if (geofencePlaceNames.length != geofences.length || geofences.length != geofenceImageUrls.length) {
             Log.e(LOG_LABEL, "Got geofence worker data arrays of differing lengths");
-            return WorkerResult.FAILURE;
+            return Result.FAILURE;
         }
 
         if (geofencesCount > 0) {
@@ -207,12 +207,12 @@ public class GeofenceTransitionWorker extends Worker {
                 }
             }
 
-            return WorkerResult.SUCCESS;
+            return Result.SUCCESS;
         } else {
             String message = "Received a geofence transition event with no triggering geofences.";
             Crashlytics.log(message);
             Log.w(LOG_LABEL, message);
-            return WorkerResult.SUCCESS;
+            return Result.SUCCESS;
         }
     }
 
@@ -250,9 +250,9 @@ public class GeofenceTransitionWorker extends Worker {
         }
     }
 
-    private WorkerResult handleError(int error) {
+    private Result handleError(int error) {
         String message = "";
-        WorkerResult result = WorkerResult.FAILURE;
+        Result result = Result.FAILURE;
         // https://developers.google.com/android/reference/com/google/android/gms/location/GeofenceStatusCodes
         switch (error) {
             case GeofenceStatusCodes.GEOFENCE_NOT_AVAILABLE:
@@ -268,15 +268,15 @@ public class GeofenceTransitionWorker extends Worker {
                 break;
             case GeofenceStatusCodes.TIMEOUT:
                 message = "Geofence timeout; retrying";
-                result = WorkerResult.RETRY;
+                result = Result.RETRY;
                 break;
             case GeofenceStatusCodes.GEOFENCE_TOO_MANY_PENDING_INTENTS:
                 message = "Too many pending intents to addGeofence. Max is 5.";
-                result =  WorkerResult.RETRY;
+                result =  Result.RETRY;
                 break;
             case GeofenceStatusCodes.API_NOT_CONNECTED:
                 message = "Geofencing prevented because API not connected";
-                result = WorkerResult.RETRY;
+                result = Result.RETRY;
                 break;
             case GeofenceStatusCodes.CANCELED:
                 message = "Geofencing cancelled";
@@ -292,7 +292,7 @@ public class GeofenceTransitionWorker extends Worker {
                 break;
             case GeofenceStatusCodes.INTERRUPTED:
                 message = "Geofencing interrupted";
-                result = WorkerResult.RETRY;
+                result = Result.RETRY;
                 break;
             default:
                 message = "Unrecognized GeofenceStatusCodes error value: " + error;

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -51,8 +51,9 @@ public class GeofenceTransitionWorker extends Worker {
     private static final String LOG_LABEL = "GeofenceTransition";
 
     // big picture style notification image should be 2:1 aspect ratio
-    private static final int NOTIFICATION_IMAGE_WIDTH = 512;
-    private static final int NOTIFICATION_IMAGE_HEIGHT = 256;
+    // https://materialdoc.com/patterns/notifications/
+    private static final int NOTIFICATION_IMAGE_WIDTH = 1024;
+    private static final int NOTIFICATION_IMAGE_HEIGHT = 512;
 
     @NonNull
     @Override

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -139,11 +139,6 @@ public class GeofenceTransitionWorker extends Worker {
                         notificationManager.cancel(notificationTag, geofenceId);
                     });
                 }
-
-                Log.d(LOG_LABEL, "Re-registering geofence after transition");
-                // remove and re-register geofence, or else it will ignore future events
-                RemoveGeofenceWorker.removeOneGeofence(geofenceLabel);
-                AddGeofencesBroadcastReceiver.addOneGeofence(longitude, latitude, geofenceLabel, placeName);
             }
 
             return WorkerResult.SUCCESS;

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -55,6 +55,9 @@ public class GeofenceTransitionWorker extends Worker {
     private static final int NOTIFICATION_IMAGE_WIDTH = 1024;
     private static final int NOTIFICATION_IMAGE_HEIGHT = 512;
 
+    private static final int BEEN_PENDING_INTENT_CODE = 101;
+    private static final int DETAIL_PENDING_INTENT_CODE = 102;
+
     @NonNull
     @Override
     @SuppressLint("StringFormatInvalid")
@@ -147,7 +150,7 @@ public class GeofenceTransitionWorker extends Worker {
                     stackBuilder.addNextIntentWithParentStack(intent);
                     // Get the PendingIntent containing the entire back stack
                     PendingIntent resultPendingIntent =
-                            stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+                            stackBuilder.getPendingIntent(DETAIL_PENDING_INTENT_CODE, PendingIntent.FLAG_UPDATE_CURRENT);
 
                     // Create pending intent for marking place "been"
                     // Add the intent to the stack builder, which inflates the back stack
@@ -155,7 +158,7 @@ public class GeofenceTransitionWorker extends Worker {
                     beenStackBuilder.addNextIntentWithParentStack(beenIntent);
                     // Get the PendingIntent containing the entire back stack
                     PendingIntent beenPendingIntent =
-                            beenStackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+                            beenStackBuilder.getPendingIntent(BEEN_PENDING_INTENT_CODE, PendingIntent.FLAG_UPDATE_CURRENT);
 
                     // Show notification on UI thread
                     handler.post(() -> {

--- a/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -32,6 +32,10 @@ public class GeofenceTransitionWorker extends Worker {
     public static final String TRANSITION_KEY = "transition";
     public static final String TRIGGERING_GEOFENCES_KEY = "triggering_geofences";
 
+    // use a one-character prefix to the geofence ID strings to disambiguate attraction IDs
+    public static final String DESTINATION_PREFIX = "d";
+    public static final String EVENT_PREFIX = "e";
+
     private static final String CHANNEL_ID = "gophillygo-nearby-places";
 
     private static final String LOG_LABEL = "GeofenceTransition";
@@ -84,8 +88,8 @@ public class GeofenceTransitionWorker extends Worker {
                 // Geofence string ID is "d" for destination or "e" for event, followed by the
                 // destination or event integer ID.
                 int geofenceId = Integer.valueOf(geofenceLabel.substring(1));
-                boolean isEvent = geofenceLabel.startsWith("e");
-                String notificationTag = isEvent ? "e" : "d";
+                boolean isEvent = geofenceLabel.startsWith(EVENT_PREFIX);
+                String notificationTag = isEvent ? EVENT_PREFIX : DESTINATION_PREFIX;
 
                 if (enteredGeofence) {
                     String message = "Entered geofence ID " + geofenceLabel + " for " + placeName;

--- a/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -27,6 +27,9 @@ public class RemoveGeofenceWorker extends Worker {
     private static final String REMOVE_GEOFENCE_TAG = "gpg-remove-geofences";
     private static final String LOG_LABEL = "RemoveGeofenceWorker";
 
+    // event identifier used for custom Crashlytics event to note a geofence was removed
+    private static final String REMOVE_GEOFENCE_EVENT = "remove_geofence";
+
     @NonNull
     @Override
     public WorkerResult doWork() {
@@ -38,7 +41,7 @@ public class RemoveGeofenceWorker extends Worker {
             Log.d(LOG_LABEL, "Going to remove " + removeGeofences.length + " geofences");
             geofencingClient.removeGeofences(new ArrayList<>(Arrays.asList(removeGeofences))).addOnSuccessListener(aVoid -> {
                 Log.d(LOG_LABEL, removeGeofences.length + " geofence(s) removed successfully");
-                Crashlytics.log("Removed geofences");
+                Crashlytics.log(REMOVE_GEOFENCE_EVENT);
             }).addOnFailureListener(e -> {
                 String errorMsg = "Failed to remove " + removeGeofences.length + " geofences.";
                 Log.d(LOG_LABEL, errorMsg);

--- a/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -38,12 +39,18 @@ public class RemoveGeofenceWorker extends Worker {
             Log.d(LOG_LABEL, "Going to remove " + removeGeofences.length + " geofences");
             geofencingClient.removeGeofences(new ArrayList<>(Arrays.asList(removeGeofences))).addOnSuccessListener(aVoid -> {
                 Log.d(LOG_LABEL, removeGeofences.length + " geofence(s) removed successfully");
+                Crashlytics.log("Removed geofences");
             }).addOnFailureListener(e -> {
-                Log.d(LOG_LABEL, "Failed to remove " + removeGeofences.length + " geofences.");
+                String errorMsg = "Failed to remove " + removeGeofences.length + " geofences.";
+                Log.d(LOG_LABEL, errorMsg);
+                Crashlytics.log(errorMsg);
+                Crashlytics.logException(e);
             });
             return WorkerResult.SUCCESS;
         } else {
-            Log.e(LOG_LABEL, "Did not receive data for geofences to remove");
+            String errorMsg = "Did not receive data for geofences to remove";
+            Log.e(LOG_LABEL, errorMsg);
+            Crashlytics.log(errorMsg);
             return WorkerResult.FAILURE;
         }
     }

--- a/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -1,16 +1,12 @@
 package com.gophillygo.app.tasks;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.LocationServices;
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
 import com.gophillygo.app.data.models.AttractionInfo;
-import com.gophillygo.app.data.models.DestinationInfo;
 import com.gophillygo.app.data.models.EventInfo;
 
 import java.util.ArrayList;
@@ -21,6 +17,9 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
 import androidx.work.Worker;
+
+import static com.gophillygo.app.tasks.GeofenceTransitionWorker.DESTINATION_PREFIX;
+import static com.gophillygo.app.tasks.GeofenceTransitionWorker.EVENT_PREFIX;
 
 public class RemoveGeofenceWorker extends Worker {
 
@@ -79,7 +78,7 @@ public class RemoveGeofenceWorker extends Worker {
     }
 
     public static void removeOneGeofence(AttractionInfo info) {
-        String prefix = info instanceof EventInfo ? "e" : "d";
+        String prefix = info instanceof EventInfo ? EVENT_PREFIX : DESTINATION_PREFIX;
         String id = String.valueOf(info.getAttraction().getId());
         removeOneGeofence(prefix + id);
     }

--- a/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/com/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -32,7 +32,7 @@ public class RemoveGeofenceWorker extends Worker {
 
     @NonNull
     @Override
-    public WorkerResult doWork() {
+    public Result doWork() {
         GeofencingClient geofencingClient = LocationServices.getGeofencingClient(getApplicationContext());
 
         Data data = getInputData();
@@ -48,12 +48,12 @@ public class RemoveGeofenceWorker extends Worker {
                 Crashlytics.log(errorMsg);
                 Crashlytics.logException(e);
             });
-            return WorkerResult.SUCCESS;
+            return Result.SUCCESS;
         } else {
             String errorMsg = "Did not receive data for geofences to remove";
             Log.e(LOG_LABEL, errorMsg);
             Crashlytics.log(errorMsg);
-            return WorkerResult.FAILURE;
+            return Result.FAILURE;
         }
     }
 

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -146,6 +146,8 @@
                     android:textAppearance="@style/GpgDetailText"
                     android:textSize="14sp"
                     android:visibility="@{destinationInfo.hasEvents ? View.VISIBLE : View.GONE}"
+                    android:text="@{@plurals/place_upcoming_activities_count(destinationInfo.getEventCount(), destinationInfo.getEventCount())}"
+                    android:onClick="@{activity::goToEvents}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.5"
@@ -166,6 +168,7 @@
 
             <android.support.v7.widget.CardView
                 android:id="@+id/place_detail_flag_options_card"
+                android:onClick="@{activity::userFlagChanged}"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"

--- a/app/src/main/res/layout/detail_description.xml
+++ b/app/src/main/res/layout/detail_description.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:showIn="@layout/activity_place_detail">
     <data>
+        <variable name="activity" type="com.gophillygo.app.activities.AttractionDetailActivity" />
         <variable name="htmlDescription" type="android.text.Spanned" />
     </data>
 
@@ -42,6 +43,7 @@
                 android:textColor="?attr/colorPrimary"
                 android:textSize="12sp"
                 android:textStyle="bold"
+                android:onClick="@{activity.toggleClickListener}"
                 app:layout_constraintTop_toBottomOf="@id/detail_description_text" />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="user_uuid_shared_preferences_key">gophillygo_user_uuid</string>
     <string name="location_network_permission_rationale">Please set location mode to \"High Accuracy\" to receive notifications when places you want to go are nearby.</string>
     <string name="channel_description">Nearby GoPhillyGo destinations you want to go visit</string>
-    <string name="place_nearby_notification">Are you visiting %1$s now? Learn more!</string>
+    <string name="place_nearby_notification">Are you visiting %1$s now? Learn more.</string>
+    <string name="place_nearby_been_button">I\'m there now</string>
     <string name="home_grid_events">Upcoming events</string>
 </resources>

--- a/example/crashlytics.properties
+++ b/example/crashlytics.properties
@@ -1,2 +1,0 @@
-apiKey=CRASHLYTICS_API_KEY
-

--- a/example/fabric.properties
+++ b/example/fabric.properties
@@ -1,0 +1,3 @@
+apiKey=FABRIC_API_KEY
+apiSecret=FABRIC_API_SECRET
+


### PR DESCRIPTION
## Overview

Add 'been' button to geofence notifications; on tap, open detail view and change flag from 'want to go' to 'been.' Add image to notification, where present, with text fallback in case image not available or fails to load for some reason. (It should always exist, though).

Also expands Crashlytics logging. Note that because we are using Crashlytics with Firebase integration, custom events are not supported, so simple log messages are sent for geofence add/remove events instead.

Also updates documentation and files for setting various app service keys for Fabric/Crashlytics support.

## Demo

![image](https://user-images.githubusercontent.com/960264/41604647-bb6d8cbc-73ad-11e8-8c7c-fb4ec5a12172.png)



## Notes

Adds some logic for notification grouping, but currently notifications will only group with the auto-grouping behavior, which happens when there are four or more. To logically group them for fewer notices would require a single notification be sent and then subsequently updated with the same identifier and with a shared title, which might make sense to do for multiple events occurring at the same location. But as that would require significant additional effort to support and will likely be implemented very differently once [support for custom locations on events](azavea/cac-tripplanner#1008) has been added, this PR does not do that. We may want to add grouping events by destination once that has been done.

## Testing

 - Mark a place or event with an associated place as 'want to go'
 - Use emulator location mock to set location to at or near the place
 - Open Maps in emulator to cause location to update
 - Notification should appear within a few minutes with the image as above
 - In-notification 'been' button should function as expected

Closes #46.
