### PR TITLE
Feature/kak/home wide images#106

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     implementation('com.github.bumptech.glide:glide:4.6.1') {
         exclude group: "com.android.support"
     }
+    implementation ("com.github.bumptech.glide:recyclerview-integration:4.7.1") {
+        transitive = false
+    }
     annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
 
     // Retrofit

--- a/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
+++ b/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
@@ -55,10 +55,10 @@ public abstract class DestinationDao implements AttractionDao<Destination> {
         }
     }
 
-    @Query("SELECT id AS attractionID, 1 AS is_event, image FROM event ORDER BY random() LIMIT 1")
+    @Query("SELECT id AS attractionID, 1 AS is_event, wide_image AS image FROM event ORDER BY random() LIMIT 1")
     protected abstract LiveData<CategoryImage> getEventCategoryImage();
 
-    @Query("SELECT id AS attractionID, 0 AS is_event, destination.image AS image " +
+    @Query("SELECT id AS attractionID, 0 AS is_event, destination.wide_image AS image " +
             "FROM destination " +
             "LEFT JOIN attractionflag " +
             "ON destination.id = attractionflag.attraction_id AND attractionflag.is_event = 0 " +
@@ -67,14 +67,14 @@ public abstract class DestinationDao implements AttractionDao<Destination> {
             "LIMIT 1")
     public abstract LiveData<CategoryImage> getRandomImagesForFlag(int flag);
 
-    @Query("SELECT id AS attractionID, 0 AS is_event, destination.image AS image " +
+    @Query("SELECT id AS attractionID, 0 AS is_event, destination.wide_image AS image " +
             "FROM destination " +
             "WHERE nature = 1 " +
             "ORDER BY random() " +
             "LIMIT 1")
     public abstract LiveData<CategoryImage> getRandomNatureImages();
 
-    @Query("SELECT id AS attractionID, 0 AS is_event, destination.image AS image " +
+    @Query("SELECT id AS attractionID, 0 AS is_event, destination.wide_image AS image " +
             "FROM destination " +
             "WHERE exercise = 1 " +
             "ORDER BY random() " +


### PR DESCRIPTION
## Overview

Modify how images are loaded on home screen into grid of categories. Use wide image instead of smaller narrow image for greater resolution, and add Glide `RecyclerView` preloader library.

## Demo

On a Nexus 9 tablet emulator:

![image](https://user-images.githubusercontent.com/960264/41743525-f63d5f1c-756e-11e8-9f43-93083ddf3920.png)


Closes #106.