### PR TITLE
Feature/kak/details from carousel#66

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,15 @@ buildscript {
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }
-apply plugin: 'com.android.application'
 
 repositories {
     maven { url 'https://maven.fabric.io/public' }
 }
 
+apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
+apply plugin: 'com.google.gms.oss.licenses.plugin'
+
 
 android {
     signingConfigs {
@@ -130,6 +132,9 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
+
+    // OSS licensing
+    implementation 'com.google.android.gms:play-services-oss-licenses:15.0.1'
 
     // testing
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,12 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.gophillygo.app.activities.HomeActivity" />
         </activity>
+        <activity android:name=".activities.GpgPreferenceActivity"
+            android:label="@string/preferences">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.gophillygo.app.activities.GpgPreferenceActivity" />
+        </activity>
         <!--
              The API key for Google Maps-based APIs is defined as a string resource.
              (See the file "res/values/api_keys.xml").

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,11 +85,29 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.gophillygo.app.activities.HomeActivity" />
         </activity>
+        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/GpgDarkTextTheme">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.gophillygo.app.activities.GpgPreferenceActivity" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/GpgDarkTextTheme">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="org.gophillygo.app.activities.GpgPreferenceActivity" />
+        </activity>
+
         <activity android:name=".activities.GpgPreferenceActivity"
             android:label="@string/preferences">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.gophillygo.app.activities.GpgPreferenceActivity" />
+                android:value="org.gophillygo.app.activities.HomeActivity" />
         </activity>
         <!--
              The API key for Google Maps-based APIs is defined as a string resource.

--- a/app/src/main/java/org/gophillygo/app/CarouselViewListener.java
+++ b/app/src/main/java/org/gophillygo/app/CarouselViewListener.java
@@ -18,12 +18,10 @@ public abstract class CarouselViewListener implements ViewListener {
 
     private final LayoutInflater inflater;
     private final Activity activity;
-    private final boolean showNearbyLabel;
 
-    public CarouselViewListener(Activity activity, boolean showNearbyLabel) {
+    public CarouselViewListener(Activity activity) {
         this.activity = activity;
         this.inflater = this.activity.getLayoutInflater();
-        this.showNearbyLabel = showNearbyLabel;
     }
 
     /**
@@ -43,7 +41,6 @@ public abstract class CarouselViewListener implements ViewListener {
                 null,
                 false);
         binding.setDestination(destination);
-        binding.setShowNearbyLabel(showNearbyLabel);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/org/gophillygo/app/activities/GpgPreferenceActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/GpgPreferenceActivity.java
@@ -1,0 +1,24 @@
+package org.gophillygo.app.activities;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+
+import org.gophillygo.app.R;
+
+public class GpgPreferenceActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_preferences);
+        setTheme(R.style.GpgPreferenceFragment);
+
+        // set up toolbar
+        Toolbar toolbar = findViewById(R.id.preferences_toolbar);
+        setSupportActionBar(toolbar);
+        //noinspection ConstantConditions
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+}

--- a/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
@@ -170,9 +170,6 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
             case R.id.action_about:
                 Log.d(LOG_LABEL, "Clicked about action");
                 break;
-            case R.id.action_logout:
-                Log.d(LOG_LABEL, "Clicked logout action");
-                break;
             default:
                 Log.w(LOG_LABEL, "Unrecognized menu option selected: " + itemId);
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.util.FixedPreloadSizeProvider;
 import com.synnapps.carouselview.CarouselView;
+import com.synnapps.carouselview.ImageClickListener;
 
 import org.gophillygo.app.CarouselViewListener;
 import org.gophillygo.app.R;
@@ -34,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.gophillygo.app.activities.FilterableListActivity.FILTER_KEY;
+import static org.gophillygo.app.activities.PlaceDetailActivity.DESTINATION_ID_KEY;
 
 
 public class HomeActivity extends BaseAttractionActivity implements DestinationRepository.CategoryAttractionCallback,
@@ -135,6 +137,17 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
         } else {
             Log.d(LOG_LABEL, "Nearest destinations collection empty; nothing to put in carousel.");
         }
+
+        // Go to place detail view on carousel interaction
+        carouselView.setImageClickListener(position -> {
+            Log.d(LOG_LABEL, "Clicked item at " + position);
+            Destination destination = getNearestDestination(position);
+            if (destination != null) {
+                Intent intent = new Intent(this, PlaceDetailActivity.class);
+                intent.putExtra(DESTINATION_ID_KEY, (long)destination.getId());
+                startActivity(intent);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
@@ -20,7 +20,6 @@ import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.util.FixedPreloadSizeProvider;
 import com.synnapps.carouselview.CarouselView;
-import com.synnapps.carouselview.ImageClickListener;
 
 import org.gophillygo.app.CarouselViewListener;
 import org.gophillygo.app.R;
@@ -29,6 +28,7 @@ import org.gophillygo.app.data.DestinationRepository;
 import org.gophillygo.app.data.models.CategoryAttraction;
 import org.gophillygo.app.data.models.Destination;
 import org.gophillygo.app.data.models.Filter;
+import org.gophillygo.app.fragments.GpgPreferenceFragment;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -166,9 +166,8 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
                 break;
             case R.id.action_settings:
                 Log.d(LOG_LABEL, "Clicked settings action");
-                break;
-            case R.id.action_about:
-                Log.d(LOG_LABEL, "Clicked about action");
+                Intent intent = new Intent(this, GpgPreferenceActivity.class);
+                startActivity(intent);
                 break;
             default:
                 Log.w(LOG_LABEL, "Unrecognized menu option selected: " + itemId);

--- a/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
@@ -19,7 +19,6 @@ import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.util.FixedPreloadSizeProvider;
-import com.bumptech.glide.util.ViewPreloadSizeProvider;
 import com.synnapps.carouselview.CarouselView;
 
 import org.gophillygo.app.CarouselViewListener;
@@ -121,7 +120,7 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
         Log.d(LOG_LABEL, "set up carousel with size: " + getNearestDestinationSize());
 
         carouselView.pauseCarousel();
-        carouselView.setViewListener(new CarouselViewListener(this, true) {
+        carouselView.setViewListener(new CarouselViewListener(this) {
             @Override
             public Destination getDestinationAt(int position) {
                 return getNearestDestination(position);

--- a/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LiveData;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.gophillygo.app.BuildConfig;
 import org.gophillygo.app.data.DestinationDao;
 import org.gophillygo.app.data.DestinationWebservice;
 import org.gophillygo.app.data.EventDao;
@@ -14,8 +15,6 @@ import org.gophillygo.app.data.models.DestinationCategories;
 import org.gophillygo.app.data.models.DestinationQueryResponse;
 import org.gophillygo.app.data.models.Event;
 import org.gophillygo.app.data.models.Filter;
-
-import org.gophillygo.app.data.EventDao;
 
 import java.util.HashSet;
 import java.util.List;
@@ -31,7 +30,8 @@ abstract public class AttractionNetworkBoundResource<A extends Attraction, I ext
         extends NetworkBoundResource<List<I>, DestinationQueryResponse> {
 
     // maximum rate at which to refresh data from network
-    private static final long RATE_LIMIT = TimeUnit.MINUTES.toMillis(15);
+    private static final long RATE_LIMIT = BuildConfig.DEBUG ? TimeUnit.MINUTES.toMillis(15):
+            TimeUnit.HOURS.toMillis(12);
 
     private final DestinationWebservice webservice;
     private final DestinationDao destinationDao;

--- a/app/src/main/java/org/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppComponent.java
@@ -3,6 +3,7 @@ package org.gophillygo.app.di;
 import android.app.Application;
 
 import org.gophillygo.app.GoPhillyGoApp;
+import org.gophillygo.app.activities.GpgPreferenceActivity;
 
 import javax.inject.Singleton;
 
@@ -28,6 +29,7 @@ import dagger.android.AndroidInjectionModule;
         PlacesListActivityModule.class,
         EventsMapsActivityModule.class,
         PlacesMapsActivityModule.class,
+        GpgPreferenceActivityModule.class,
 
         // Broadcast Receivers
         AddGeofenceBroadcastReceiverModule.class,

--- a/app/src/main/java/org/gophillygo/app/di/AppComponent.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppComponent.java
@@ -30,6 +30,8 @@ import dagger.android.AndroidInjectionModule;
         EventsMapsActivityModule.class,
         PlacesMapsActivityModule.class,
         GpgPreferenceActivityModule.class,
+        OssLicensesMenuActivityModule.class,
+        OssLicensesActivityModule.class,
 
         // Broadcast Receivers
         AddGeofenceBroadcastReceiverModule.class,

--- a/app/src/main/java/org/gophillygo/app/di/GpgPreferenceActivityModule.java
+++ b/app/src/main/java/org/gophillygo/app/di/GpgPreferenceActivityModule.java
@@ -1,0 +1,12 @@
+package org.gophillygo.app.di;
+
+import org.gophillygo.app.activities.GpgPreferenceActivity;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+@Module
+public abstract class GpgPreferenceActivityModule {
+    @ContributesAndroidInjector
+    abstract GpgPreferenceActivity contributeGpgPreferenceActivity();
+}

--- a/app/src/main/java/org/gophillygo/app/di/OssLicensesActivityModule.java
+++ b/app/src/main/java/org/gophillygo/app/di/OssLicensesActivityModule.java
@@ -1,0 +1,12 @@
+package org.gophillygo.app.di;
+
+import com.google.android.gms.oss.licenses.OssLicensesActivity;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+@Module
+public abstract class OssLicensesActivityModule {
+    @ContributesAndroidInjector
+    abstract OssLicensesActivity contributeOssLicensesActivityModule();
+}

--- a/app/src/main/java/org/gophillygo/app/di/OssLicensesMenuActivityModule.java
+++ b/app/src/main/java/org/gophillygo/app/di/OssLicensesMenuActivityModule.java
@@ -1,0 +1,12 @@
+package org.gophillygo.app.di;
+
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
+
+import dagger.Module;
+import dagger.android.ContributesAndroidInjector;
+
+@Module
+abstract public class OssLicensesMenuActivityModule {
+    @ContributesAndroidInjector
+    abstract OssLicensesMenuActivity contributeOssLicensesMenuActivityModule();
+}

--- a/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
+++ b/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
@@ -1,0 +1,16 @@
+package org.gophillygo.app.fragments;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.support.annotation.Nullable;
+
+import org.gophillygo.app.R;
+
+public class GpgPreferenceFragment extends PreferenceFragment {
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.preferences);
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -6,9 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="org.gophillygo.app.activities.HomeActivity"
-    android:id="@+id/relativeLayout">
+    android:id="@+id/home_activity_scrollview">
 
     <android.support.constraint.ConstraintLayout
+        android:id="@+id/home_activity_main_content"
         android:layout_height="wrap_content"
         android:layout_width="match_parent" >
 

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".activities.GpgPreferenceActivity"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.design.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/preferences_app_bar"
+            android:fitsSystemWindows="true"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/preferences_toolbar"
+                style="@style/ToolbarTransparent"
+                android:background="@color/color_primary"
+                app:title="@string/preferences"
+                tools:targetApi="lollipop" />
+        </android.support.design.widget.AppBarLayout>
+
+        <fragment
+            android:name="org.gophillygo.app.fragments.GpgPreferenceFragment"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            app:layout_constraintTop_toBottomOf="@id/preferences_app_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:id="@+id/preferences_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </android.support.design.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/custom_carousel_item.xml
+++ b/app/src/main/res/layout/custom_carousel_item.xml
@@ -57,20 +57,6 @@
                 android:text="@{destination.getFormattedDistance}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent" />
-
-            <TextView
-                android:id="@+id/carousel_item_nearby_label"
-                style="@style/Base.TextAppearance.AppCompat.Title.Inverse"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                android:layout_marginRight="16dp"
-                android:text="@string/carousel_nearby_label"
-                android:textAlignment="textEnd"
-                android:textSize="12sp"
-                android:visibility="@{showNearbyLabel ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintRight_toRightOf="parent" />
         </android.support.constraint.ConstraintLayout>
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -19,10 +19,4 @@
         android:orderInCategory="3"
         app:showAsAction="never"
         android:title="@string/menu_action_about"/>
-
-    <item
-        android:id="@+id/action_logout"
-        android:orderInCategory="4"
-        app:showAsAction="never"
-        android:title="@string/menu_action_logout"/>
 </menu>

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -13,10 +13,4 @@
         android:orderInCategory="2"
         app:showAsAction="never"
         android:title="@string/menu_action_settings"/>
-
-    <item
-        android:id="@+id/action_about"
-        android:orderInCategory="3"
-        app:showAsAction="never"
-        android:title="@string/menu_action_about"/>
 </menu>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ListItem">
+        <item name="android:layout_margin">8dp</item>
+        <item name="android:background">@color/color_white</item>
+        <item name="android:elevation">2dp</item>
+    </style>
+
+    <style name="ToolbarOpaque" parent="ToolbarTransparent">
+        <item name="android:background">@color/color_primary</item>
+        <item name="android:elevation">0dp</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,4 +95,18 @@
     <string name="place_nearby_notification">Are you visiting %1$s now? Learn more.</string>
     <string name="place_nearby_been_button">I\'m there now</string>
     <string name="home_grid_events">Upcoming events</string>
+    <string name="general_preference_category">General</string>
+
+    <!-- shared preferences settings key -->
+    <string name="general_preferences_key" translatable="false">gophillygo_general_preferences</string>
+    <string name="preferences_fine_print_key" translatable="false">gophillygo_preferences_fine_print</string>
+
+    <!-- settings -->
+    <string name="general_preference_notifications">Notifications</string>
+    <string name="preferences_fine_print">Fine print</string>
+    <string name="preferences_app_info">App info</string>
+    <string name="preferences_licences">Licenses</string>
+    <string name="preferences_privacy">Privacy</string>
+    <string name="preferences_terms_of_service">Terms of service</string>
+    <string name="preferences">Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="menu_search_action">Search</string>
     <string name="menu_action_settings">Settings</string>
     <string name="menu_action_about">About</string>
-    <string name="menu_action_logout">Sign out</string>
     <string name="menu_action_events">Go to events</string>
     <string name="menu_action_places">Go to places</string>
     <string name="menu_action_map">See map</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,14 +22,12 @@
         <item name="android:background">@null</item>
         <item name="android:layout_alignParentTop">true</item>
         <item name="android:fitsSystemWindows">true</item>
-        <item name="android:elevation">4dp</item>
         <item name="android:theme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
     </style>
 
     <style name="ToolbarOpaque" parent="ToolbarTransparent">
         <item name="android:background">@color/color_primary</item>
-        <item name="android:elevation">0dp</item>
     </style>
 
     <style name="Carousel">
@@ -93,7 +91,6 @@
     <style name="ListItem">
         <item name="android:layout_margin">8dp</item>
         <item name="android:background">@color/color_white</item>
-        <item name="android:elevation">2dp</item>
     </style>
 
 
@@ -207,18 +204,19 @@
         <item name="android:drawableStart">@drawable/ic_place_white_16dp</item>
     </style>
 
-    <style name="ItemDetailFlag" parent="TextAppearance.AppCompat.Title">
+    <style name="GpgTextAppearanceTitle" parent="TextAppearance.AppCompat.Title">
         <item name="android:textColor">@color/color_black</item>
         <item name="android:fontFamily">sans-serif</item>
+    </style>
+
+    <style name="ItemDetailFlag" parent="GpgTextAppearanceTitle">
         <item name="android:textSize">15sp</item>
         <item name="android:padding">16dp</item>
         <item name="android:layout_height">56dp</item>
         <item name="android:gravity">center_vertical</item>
     </style>
 
-    <style name="ItemDetailDescription" parent="TextAppearance.AppCompat.Title">
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
+    <style name="ItemDetailDescription" parent="GpgTextAppearanceTitle">
         <item name="android:textSize">13sp</item>
         <item name="android:padding">0dp</item>
         <item name="android:lineSpacingMultiplier">1.2</item>
@@ -230,9 +228,7 @@
         <item name="android:ellipsize">end</item>
     </style>
 
-    <style name="ItemDetailDescriptionToggle" parent="TextAppearance.AppCompat.Title">
-        <item name="android:textColor">@color/color_primary</item>
-        <item name="android:fontFamily">sans-serif</item>
+    <style name="ItemDetailDescriptionToggle" parent="GpgTextAppearanceTitle">
         <item name="android:textSize">12sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textAlignment">center</item>
@@ -240,22 +236,23 @@
         <item name="android:layout_marginBottom">8dp</item>
     </style>
 
-    <style name="PlaceDetailActivity" parent="TextAppearance.AppCompat.Title">
+    <style name="PlaceDetailActivity" parent="GpgTextAppearanceTitle">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_marginEnd">8dp</item>
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">14sp</item>
         <item name="android:padding">0dp</item>
         <item name="android:drawablePadding">6dp</item>
     </style>
 
-    <style name="EventDetailDate" parent="TextAppearance.AppCompat.Title">
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
+    <style name="GpgPreferenceFragment">
+        <item name="android:textAppearance">@style/GpgTextAppearanceTitle</item>
+        <item name="android:textColorPrimary">@color/color_text_dark_grey</item>
+    </style>
+
+    <style name="EventDetailDate" parent="GpgTextAppearanceTitle">
         <item name="android:textSize">22sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textAlignment">center</item>
@@ -265,9 +262,7 @@
         <item name="android:padding">0dp</item>
     </style>
 
-    <style name="EventDetailLocation" parent="TextAppearance.AppCompat.Title">
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
+    <style name="EventDetailLocation" parent="GpgTextAppearanceTitle">
         <item name="android:textSize">20sp</item>
         <item name="android:textAlignment">center</item>
         <item name="android:layout_marginEnd">8dp</item>
@@ -276,13 +271,12 @@
         <item name="android:padding">0dp</item>
     </style>
 
-    <style name="PlaceListItemName" parent="TextAppearance.AppCompat.Title">
+    <style name="PlaceListItemName" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_marginEnd">8dp</item>
         <item name="android:layout_marginTop">12dp</item>
         <item name="android:padding">0dp</item>
-        <item name="android:fontFamily">sans-serif</item>
-        <item name="android:textColor">@color/color_black</item>
+
         <item name="android:textSize">18sp</item>
     </style>
 
@@ -299,24 +293,20 @@
         <item name="android:drawableStart">@drawable/ic_place_gray_16dp</item>
     </style>
 
-    <style name="EventListItemMonth" parent="TextAppearance.AppCompat.Title">
+    <style name="EventListItemMonth" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginEnd">16dp</item>
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:padding">0dp</item>
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">13sp</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textAlignment">center</item>
     </style>
 
-    <style name="EventListItemDayOfMonth" parent="TextAppearance.AppCompat.Title">
+    <style name="EventListItemDayOfMonth" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginEnd">16dp</item>
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:padding">0dp</item>
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">32sp</item>
         <item name="android:textAlignment">center</item>
     </style>
@@ -333,23 +323,19 @@
         <item name="android:textAlignment">center</item>
     </style>
 
-    <style name="EventListItemName" parent="TextAppearance.AppCompat.Title">
+    <style name="EventListItemName" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginEnd">8dp</item>
         <item name="android:layout_marginStart">72dp</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:padding">0dp</item>
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">18sp</item>
     </style>
 
-    <style name="EventListItemDestination" parent="TextAppearance.AppCompat.Title">
+    <style name="EventListItemDestination" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginEnd">8dp</item>
         <item name="android:layout_marginStart">72dp</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:padding">0dp</item>
-        <item name="android:textColor">@color/color_black</item>
-        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textSize">13sp</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,6 +14,16 @@
         <item name="android:textColorPrimary">@color/text_color_primary</item>
     </style>
 
+    <style name="GpgDarkTextTheme" parent="Base.Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark</item>
+        <item name="colorAccent">@color/color_accent</item>
+        <item name="android:windowBackground">@color/color_background_grey</item>
+        <item name="android:fitsSystemWindows">true</item>
+        <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="android:textColorSecondary">@color/color_text_dark_grey</item>
+        <item name="android:textAppearance">@style/GpgTextAppearanceTitle</item>
+    </style>
 
     <!-- components -->
     <style name="ToolbarTransparent">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -19,7 +19,8 @@
             android:title="@string/preferences_licences">
             <intent
                 android:action="android.intent.action.VIEW"
-                android:targetClass="OssLicensesMenuActivity.class" />
+                android:targetPackage="org.gophillygo.app"
+                android:targetClass="com.google.android.gms.oss.licenses.OssLicensesMenuActivity" />
         </Preference>
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+        android:title="@string/general_preference_category"
+        android:key="@string/general_preferences_key">
+        <Preference
+            android:title="@string/general_preference_notifications" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:title="@string/preferences_fine_print"
+        android:key="@string/preferences_fine_print_key">
+        <Preference
+            android:title="@string/preferences_app_info" />
+        <Preference
+            android:title="@string/preferences_terms_of_service" />
+        <Preference
+            android:title="@string/preferences_privacy" />
+        <Preference
+            android:title="@string/preferences_licences" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -16,7 +16,11 @@
         <Preference
             android:title="@string/preferences_privacy" />
         <Preference
-            android:title="@string/preferences_licences" />
+            android:title="@string/preferences_licences">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:targetClass="OssLicensesMenuActivity.class" />
+        </Preference>
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         // https://firebase.google.com/docs/crashlytics/get-started
         classpath 'io.fabric.tools:gradle:1.25.4'
         classpath 'com.google.gms:google-services:4.0.1'
+        classpath 'com.google.gms:oss-licenses:0.9.2'
     }
 }
 


### PR DESCRIPTION
## Overview

Adds settings screen with OSS licenses view, and closes assorted small issues.

## Demo

Main settings page:
![screenshot_1529691154](https://user-images.githubusercontent.com/960264/41795007-50c0b9fa-762f-11e8-9946-f81a6252fa39.png)

Bottom sheet prompt on selecting 'Licenses':

![screenshot_1529694732](https://user-images.githubusercontent.com/960264/41795024-62ac9ada-762f-11e8-9268-9f2e68c15430.png)

Licenses "menu" list (autogenerated):
![screenshot_1529694726](https://user-images.githubusercontent.com/960264/41795042-71c8aee6-762f-11e8-9f79-3c13a4ada1c7.png)

License detail view, also autogenerated, navigated to from above menu:

![screenshot_1529694722](https://user-images.githubusercontent.com/960264/41795067-8528c458-762f-11e8-82e9-3c8029e4eb70.png)

## Testing

 - Click 'settings' from home view menu
 - Click 'Licenses' from settings view
 - Pick a library; should get a license detail view
 - Toolbars and text should look okay
 - Back navigation should return as expected, with the home view at the top level
 - Tapping on a home view carousel item should go to its detail view
 - 'Nearby' label should be gone from carousel

Closes #100 
Closes #93 
Closes #91 
Closes #27 