### PR TITLE
Differ user flag strings for places and events

### DIFF
--- a/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
@@ -19,6 +19,7 @@ import com.synnapps.carouselview.CarouselView;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.models.Attraction;
+import org.gophillygo.app.data.models.AttractionFlag;
 import org.gophillygo.app.data.models.AttractionInfo;
 import org.gophillygo.app.data.models.DestinationInfo;
 import org.gophillygo.app.data.models.DestinationLocation;
@@ -168,5 +169,26 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
             Glide.with(this).load(url).into(imageView);
         });
         carouselView.setPageCount(attraction.getExtraWideImages().size() + 1);
+    }
+
+    /**
+     * Gets the user-presentable detail string for a user flag (been, want to go, etc.)
+     *
+     * @param info AttractionInfo object for a place or event
+     * @return String from string resources; varies for places and events
+     */
+    public String getFlagLabel(AttractionInfo info) {
+        if (info == null || info.getAttraction() == null) {
+            String msg = "Cannot get flag label for missing object";
+            Log.e(LOG_LABEL, msg);
+            Crashlytics.log(msg);
+            return getString(R.string.place_detail_unset);
+        }
+
+        AttractionFlag flag = info.getFlag();
+        getString(R.string.place_detail_unset);
+        return info.getAttraction().isEvent() ?
+                getString(flag.getOption().eventLabel) :
+                getString(flag.getOption().placeLabel);
     }
 }

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -132,6 +132,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
             // set up data binding object
             binding.setEvent(eventInfo.getEvent());
             binding.setEventInfo(eventInfo);
+            binding.setAttractionInfo(eventInfo);
             binding.eventDetailDescriptionCard.detailDescriptionToggle.setOnClickListener(toggleClickListener);
             displayEvent();
         });
@@ -203,10 +204,10 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
     private void updateFlag(int itemId) {
         boolean haveExistingGeofence = eventInfo.getFlag().getOption()
-                .api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
         eventInfo.updateAttractionFlag(itemId);
         viewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
-        Boolean settingGeofence = eventInfo.getFlag().getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+        Boolean settingGeofence = eventInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
         addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
         binding.notifyPropertyChanged(BR.destinationInfo);
     }

--- a/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
@@ -65,7 +65,7 @@ public class EventsListActivity extends FilterableListActivity
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {
         Boolean haveExistingGeofence = eventInfo.getFlag()
-                .getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+                .getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
 
         eventInfo.updateAttractionFlag(item.getItemId());
         viewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
@@ -73,7 +73,7 @@ public class EventsListActivity extends FilterableListActivity
 
         // do not attempt to add a geofence for an event with no location
         if (((EventInfo)eventInfo).hasDestinationName()) {
-            Boolean settingGeofence = eventInfo.getFlag().getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+            Boolean settingGeofence = eventInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
             addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
         } else {
             // TODO: notify user?

--- a/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
@@ -158,13 +158,13 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
         PopupMenu menu = FlagMenuUtils.getFlagPopupMenu(this, view, info.getFlag());
         menu.setOnMenuItemClickListener(item -> {
             Boolean haveExistingGeofence = info.getFlag().getOption()
-                    .api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+                    .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
 
             info.updateAttractionFlag(item.getItemId());
             viewModel.updateAttractionFlag(info.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
             popupBinding.setAttractionInfo(info);
             popupBinding.setAttraction(info.getAttraction());
-            Boolean settingGeofence = info.getFlag().getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+            Boolean settingGeofence = info.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
             addOrRemoveGeofence(info, haveExistingGeofence, settingGeofence);
             return true;
         });

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -24,8 +24,6 @@ import org.gophillygo.app.tasks.GeofenceTransitionWorker;
 
 import javax.inject.Inject;
 
-import static org.gophillygo.app.tasks.GeofenceTransitionWorker.MARK_BEEN_KEY;
-
 public class PlaceDetailActivity extends AttractionDetailActivity {
 
     public static final String DESTINATION_ID_KEY = "place_id";
@@ -92,6 +90,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
             // set up data binding object
             binding.setDestination(destinationInfo.getDestination());
             binding.setDestinationInfo(destinationInfo);
+            binding.setAttractionInfo(destinationInfo);
             binding.setActivity(this);
             binding.setContext(this);
             binding.placeDetailDescriptionCard.detailDescriptionToggle.setOnClickListener(toggleClickListener);
@@ -122,7 +121,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
             return;
         }
         Boolean haveExistingGeofence = destinationInfo.getFlag().getOption()
-                .api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
         destinationInfo.updateAttractionFlag(itemId);
         viewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
         Boolean settingGeofence = itemId  == AttractionFlag.Option.WantToGo.code;

--- a/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
@@ -69,12 +69,12 @@ public class PlacesListActivity extends FilterableListActivity implements
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo destinationInfo, Integer position) {
         Boolean haveExistingGeofence = destinationInfo.getFlag().getOption()
-                .api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
 
         destinationInfo.updateAttractionFlag(item.getItemId());
         viewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
         placesListAdapter.notifyItemChanged(position);
-        Boolean settingGeofence = destinationInfo.getFlag().getOption().api_name.equals(AttractionFlag.Option.WantToGo.api_name);
+        Boolean settingGeofence = destinationInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
         addOrRemoveGeofence(destinationInfo, haveExistingGeofence, settingGeofence);
 	    return true;
     }

--- a/app/src/main/java/org/gophillygo/app/data/DestinationRepository.java
+++ b/app/src/main/java/org/gophillygo/app/data/DestinationRepository.java
@@ -99,7 +99,7 @@ public class DestinationRepository {
             }
         }.execute();
 
-        UserFlagPost post = new UserFlagPost(flag.getAttractionID(), flag.getOption().api_name,
+        UserFlagPost post = new UserFlagPost(flag.getAttractionID(), flag.getOption().apiName,
                 flag.isEvent(), userUuid, apiKey);
 
         webservice.postUserFlag(post).enqueue(new Callback<UserFlagPostResponse>() {

--- a/app/src/main/java/org/gophillygo/app/data/models/AttractionFlag.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/AttractionFlag.java
@@ -7,6 +7,7 @@ import android.arch.persistence.room.TypeConverter;
 import android.arch.persistence.room.TypeConverters;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
+import android.support.annotation.StringRes;
 import android.util.SparseArray;
 
 import com.google.gson.annotations.SerializedName;
@@ -19,11 +20,16 @@ import java.util.Objects;
 public class AttractionFlag {
 
     public enum Option {
-        NotSelected (0, R.drawable.ic_add_black_24dp, null, ""),
-        Liked (1, R.drawable.ic_thumb_up_blue_24dp, R.id.place_option_liked, "liked"),
-        NotInterested (2, R.drawable.ic_not_interested_blue_24dp, R.id.place_option_not_interested, "not_interested"),
-        Been (3, R.drawable.ic_beenhere_blue_24dp, R.id.place_option_been, "been"),
-        WantToGo (4, R.drawable.ic_flag_blue_24dp, R.id.place_option_want_to_go, "want_to_go");
+        NotSelected (0, R.drawable.ic_add_black_24dp, null, "",
+                R.string.place_detail_unset, R.string.event_detail_unset),
+        Liked (1, R.drawable.ic_thumb_up_blue_24dp, R.id.place_option_liked, "liked",
+                R.string.place_detail_liked, R.string.event_detail_liked),
+        NotInterested (2, R.drawable.ic_not_interested_blue_24dp, R.id.place_option_not_interested, "not_interested",
+                R.string.place_detail_not_interested, R.string.event_detail_not_interested),
+        Been (3, R.drawable.ic_beenhere_blue_24dp, R.id.place_option_been, "been",
+                R.string.place_detail_been, R.string.event_detail_been),
+        WantToGo (4, R.drawable.ic_flag_blue_24dp, R.id.place_option_want_to_go, "want_to_go",
+                R.string.place_detail_want_to_go, R.string.event_detail_want_to_go);
 
         private static final SparseArray<Option> map = new SparseArray<>();
         static {
@@ -35,13 +41,18 @@ public class AttractionFlag {
         public final int code;
         public final @DrawableRes int drawable;
         public final @IdRes Integer id;
-        public final String api_name;
+        public final String apiName;
+        public final @StringRes Integer placeLabel;
+        public final @StringRes Integer eventLabel;
 
-        Option(int code, @DrawableRes int drawable, @IdRes Integer id, String api_name) {
+        Option(int code, @DrawableRes int drawable, @IdRes Integer id, String apiName,
+               @StringRes Integer placeLabel, @StringRes Integer eventLabel) {
             this.code = code;
             this.drawable = drawable;
             this.id = id;
-            this.api_name = api_name;
+            this.apiName = apiName;
+            this.placeLabel = placeLabel;
+            this.eventLabel = eventLabel;
         }
 
         public static Option valueOf(int code) {

--- a/app/src/main/java/org/gophillygo/app/data/models/CategoryAttraction.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/CategoryAttraction.java
@@ -50,8 +50,8 @@ public class CategoryAttraction {
      */
     public enum PlaceCategories {
         Events(0, R.string.home_grid_events, EVENTS_API_NAME),
-        WantToGo(1, R.string.place_want_to_go_option, AttractionFlag.Option.WantToGo.api_name),
-        Liked(2, R.string.place_liked_option, AttractionFlag.Option.Liked.api_name),
+        WantToGo(1, R.string.place_want_to_go_option, AttractionFlag.Option.WantToGo.apiName),
+        Liked(2, R.string.place_liked_option, AttractionFlag.Option.Liked.apiName),
         Nature(3, R.string.nature_category_label, NATURE_API_NAME),
         Exercise(4, R.string.exercise_category_label, EXERCISE_API_NAME),
         Educational(5, R.string.educational_category_label, EDUCATIONAL_API_NAME);

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -9,6 +9,7 @@
         <variable name="event" type="org.gophillygo.app.data.models.Event"/>
         <variable name="eventInfo" type="org.gophillygo.app.data.models.EventInfo"/>
         <variable name="destination" type="org.gophillygo.app.data.models.Destination"/>
+        <variable name="attractionInfo" type="org.gophillygo.app.data.models.AttractionInfo"/>
         <variable name="activity" type="org.gophillygo.app.activities.EventDetailActivity" />
         <variable name="context" type="android.content.Context" />
         <!-- imports to allow referencing within data binding expressions -->
@@ -118,7 +119,7 @@
                     style="@style/ItemDetailFlag"
                     android:layout_width="match_parent"
                     android:drawableEnd="@{activity.getFlagImage(eventInfo)}"
-                    android:text="@string/event_details_been_want_to_go_label" />
+                    android:text="@{activity.getFlagLabel(attractionInfo)}" />
 
             </android.support.v7.widget.CardView>
 

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -7,6 +7,7 @@
         <!-- set up data binding to destination -->
         <variable name="destination" type="org.gophillygo.app.data.models.Destination"/>
         <variable name="destinationInfo" type="org.gophillygo.app.data.models.DestinationInfo"/>
+        <variable name="attractionInfo" type="org.gophillygo.app.data.models.AttractionInfo"/>
         <variable name="activity" type="org.gophillygo.app.activities.PlaceDetailActivity" />
         <variable name="context" type="android.content.Context" />
         <!-- imports to allow referencing within data binding expressions -->
@@ -139,7 +140,7 @@
                     style="@style/ItemDetailFlag"
                     android:layout_width="match_parent"
                     android:drawableEnd="@{activity.getFlagImage(destinationInfo)}"
-                    android:text="@string/place_details_been_want_to_go_label" />
+                    android:text="@{activity.getFlagLabel(attractionInfo)}" />
 
             </android.support.v7.widget.CardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,17 @@
     <string name="place_been_option">Been</string>
     <string name="place_want_to_go_option">Want to go</string>
 
-    <string name="carousel_nearby_label">Nearby</string>
+    <!-- User flags -->
+    <string name="place_detail_unset">Been here? Want to go?</string>
+    <string name="event_detail_unset">Want to go?</string>
+    <string name="place_detail_want_to_go">You want to go here!</string>
+    <string name="event_detail_want_to_go">You want to go to this!</string>
+    <string name="place_detail_been">You\'ve been here</string>
+    <string name="event_detail_been">You\'ve been to this</string>
+    <string name="place_detail_liked">You liked this place!</string>
+    <string name="event_detail_liked">You liked this event!</string>
+    <string name="place_detail_not_interested">You\'re not interested</string>
+    <string name="event_detail_not_interested">You\'re not interested</string>
 
     <string name="places_list_title">Places</string>
     <string name="events_list_title">Events</string>
@@ -50,8 +60,6 @@
     </plurals>
 
     <string name="distance_with_abbreviated_miles">%s mi</string>
-
-    <string name="place_details_been_want_to_go_label">Been here? Want to go?</string>
 
     <string name="place_detail_map_button">Map</string>
     <string name="place_detail_directions_button">Directions</string>


### PR DESCRIPTION
## Overview
Set display strings for user flags that are different for place details and event details.

## Demo

### Places:
![places_flags](https://user-images.githubusercontent.com/960264/42238175-fd8207b0-7ecd-11e8-983f-40eeacd2a172.gif)

### Events:
![event_flags](https://user-images.githubusercontent.com/960264/42238178-ffa2b0bc-7ecd-11e8-904a-a9259f54f41a.gif)


Closes #65.