### PR TITLE
Feature/kak/inline events detail#113

### DIFF
--- a/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
@@ -186,9 +186,6 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
      */
     public String getFlagLabel(AttractionInfo info) {
         if (info == null || info.getAttraction() == null) {
-            String msg = "Cannot get flag label for missing object";
-            Log.e(LOG_LABEL, msg);
-            Crashlytics.log(msg);
             return getString(R.string.place_detail_unset);
         }
 

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -13,6 +13,7 @@ import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListView;
+import android.widget.ScrollView;
 
 import com.crashlytics.android.Crashlytics;
 
@@ -111,7 +112,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
 
             // set up list of related events
             if (destinationInfo.getEventCount() > 0) {
-                RecyclerView eventsList = findViewById(R.id.place_detail_list_recycler_view);
+                RecyclerView eventsList = findViewById(R.id.place_detail_events_recycler_view);
                 // set adapter for related events
                 eventViewModel.getEventsForDestination(placeId).observe(this, events -> {
                     if (events != null) {
@@ -164,9 +165,15 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
         binding.notifyPropertyChanged(BR.destinationInfo);
     }
 
-    // TODO: #113 scroll to bottom, where events are listed inline with the view
+    /**
+     * Scroll to head of inline events list when calendar count summary clicked.
+     *
+     * @param view View clicked (required parameter for binding)
+     */
     public void goToEvents(View view) {
-        Log.d(LOG_LABEL, "Clicked events in destination. TODO: #113");
+        ScrollView scrollView = findViewById(R.id.place_detail_scroll_view);
+        scrollView.scrollTo(0, findViewById(R.id.place_detail_events_recycler_view).getTop());
+
     }
 
     @Override

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -13,7 +13,6 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.ListView;
 import android.widget.ScrollView;
 
 import com.crashlytics.android.Crashlytics;
@@ -211,7 +210,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
                 .getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
 
         eventInfo.updateAttractionFlag(item.getItemId());
-        eventViewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key));
+        eventViewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key), UserUtils.isFlagPostingEnabled(this));
         eventsList.getAdapter().notifyItemChanged(position);
 
         // do not attempt to add a geofence for an event with no location (should always exist here,

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -5,17 +5,25 @@ import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.PopupMenu;
+import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.MenuItem;
 import android.view.View;
+import android.widget.ListView;
 
 import com.crashlytics.android.Crashlytics;
 
 import org.gophillygo.app.BR;
 import org.gophillygo.app.R;
+import org.gophillygo.app.adapters.AttractionListAdapter;
+import org.gophillygo.app.adapters.EventsListAdapter;
 import org.gophillygo.app.data.DestinationViewModel;
+import org.gophillygo.app.data.EventViewModel;
 import org.gophillygo.app.data.models.AttractionFlag;
+import org.gophillygo.app.data.models.AttractionInfo;
 import org.gophillygo.app.data.models.DestinationInfo;
 import org.gophillygo.app.databinding.ActivityPlaceDetailBinding;
 import org.gophillygo.app.di.GpgViewModelFactory;
@@ -25,7 +33,7 @@ import org.gophillygo.app.utils.UserUtils;
 
 import javax.inject.Inject;
 
-public class PlaceDetailActivity extends AttractionDetailActivity {
+public class PlaceDetailActivity extends AttractionDetailActivity implements AttractionListAdapter.AttractionListItemClickListener {
 
     public static final String DESTINATION_ID_KEY = "place_id";
     private static final String LOG_LABEL = "PlaceDetail";
@@ -37,7 +45,9 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
     @Inject
     GpgViewModelFactory viewModelFactory;
     @SuppressWarnings("WeakerAccess")
-    DestinationViewModel viewModel;
+    DestinationViewModel destinationViewModel;
+    @SuppressWarnings("WeakerAccess")
+    EventViewModel eventViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -64,9 +74,11 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
         binding.placeDetailCarousel.setImageClickListener(position ->
                 Log.d(LOG_LABEL, "Clicked item: "+ position));
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        destinationViewModel = ViewModelProviders.of(this, viewModelFactory)
                 .get(DestinationViewModel.class);
-        LiveData<DestinationInfo> data = viewModel.getDestination(placeId);
+        LiveData<DestinationInfo> data = destinationViewModel.getDestination(placeId);
+
+        eventViewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
 
         data.observe(this, destinationInfo -> {
             // TODO: #61 handle if destination not found (go to list of destinations?)
@@ -96,6 +108,28 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
             binding.setContext(this);
             binding.placeDetailDescriptionCard.detailDescriptionToggle.setOnClickListener(toggleClickListener);
             displayDestination();
+
+            // set up list of related events
+            if (destinationInfo.getEventCount() > 0) {
+                RecyclerView eventsList = findViewById(R.id.place_detail_list_recycler_view);
+                // set adapter for related events
+                eventViewModel.getEventsForDestination(placeId).observe(this, events -> {
+                    if (events != null) {
+                        if (events.size() != destinationInfo.getEventCount()) {
+                            Log.e(LOG_LABEL, "Event count mismatch. Summary has " + destinationInfo.getEventCount() +
+                            "but query found " + events.size());
+                            return;
+                        }
+
+                        eventsList.setAdapter(new EventsListAdapter(this, events, this));
+                        eventsList.setLayoutManager(new LinearLayoutManager(this));
+                    } else {
+                        Log.e(LOG_LABEL, "no events found for destination, but event count is " + destinationInfo.getEventCount());
+                        eventsList.setVisibility(View.INVISIBLE);
+                    }
+                });
+            }
+
         });
     }
 
@@ -124,9 +158,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity {
         Boolean haveExistingGeofence = destinationInfo.getFlag().getOption()
                 .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
         destinationInfo.updateAttractionFlag(itemId);
-
-        viewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key),
-                UserUtils.isFlagPostingEnabled(this));
+        destinationViewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key), UserUtils.isFlagPostingEnabled(this));
         Boolean settingGeofence = itemId  == AttractionFlag.Option.WantToGo.code;
         addOrRemoveGeofence(destinationInfo, haveExistingGeofence, settingGeofence);
         binding.notifyPropertyChanged(BR.destinationInfo);

--- a/app/src/main/java/org/gophillygo/app/data/DestinationRepository.java
+++ b/app/src/main/java/org/gophillygo/app/data/DestinationRepository.java
@@ -66,6 +66,10 @@ public class DestinationRepository {
         return eventDao.getEvent(eventId);
     }
 
+    public LiveData<List<EventInfo>> getEventsForDestination(long destinationId) {
+        return eventDao.getEventsForDestination(destinationId);
+    }
+
     @SuppressLint("StaticFieldLeak")
     public void updateDestination(Destination destination) {
         new AsyncTask<Void, Void, Void>() {

--- a/app/src/main/java/org/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/org/gophillygo/app/data/EventDao.java
@@ -28,6 +28,18 @@ public abstract class EventDao implements AttractionDao<Event> {
             "ORDER BY event.start_date ASC;")
     public abstract LiveData<List<EventInfo>> getAll();
 
+    @Transaction
+    @Query("SELECT event.*, destination.name AS destinationName, NULL AS distance, " +
+            "destination.categories AS destinationCategories, attractionflag.option, " +
+            "destination.x, destination.y, destination.distance " +
+            "FROM event " +
+            "LEFT JOIN destination ON destination._id = event.destination " +
+            "LEFT JOIN attractionflag " +
+            "ON event._id = attractionflag.attraction_id AND attractionflag.is_event = 1 " +
+            "WHERE destination._id = :destinationId " +
+            "ORDER BY event.start_date ASC;")
+    public abstract LiveData<List<EventInfo>> getEventsForDestination(long destinationId);
+
     @Query("SELECT event.*, destination.name AS destinationName, " +
             "destination.categories AS destinationCategories, attractionflag.option, " +
             "destination.distance AS distance, destination.x, destination.y, destination.watershed_alliance " +

--- a/app/src/main/java/org/gophillygo/app/data/EventViewModel.java
+++ b/app/src/main/java/org/gophillygo/app/data/EventViewModel.java
@@ -25,6 +25,10 @@ public class EventViewModel extends AttractionViewModel {
         return destinationRepository.getEvent(eventId);
     }
 
+    public LiveData<List<EventInfo>> getEventsForDestination(long destinationId) {
+        return destinationRepository.getEventsForDestination(destinationId);
+    }
+
     public void updateEvent(Event event) {
         destinationRepository.updateEvent(event);
     }

--- a/app/src/main/java/org/gophillygo/app/data/models/EventInfo.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/EventInfo.java
@@ -80,8 +80,8 @@ public class EventInfo extends AttractionInfo<Event> {
     }
 
     @Override
-    public String getFormattedDistance() {
-        if (distance == null || context == null) {
+    public String getFormattedDistance(Context context) {
+        if (distance == null) {
             return "";
         }
         return numberFormatter.format(distance.floatValue());

--- a/app/src/main/java/org/gophillygo/app/data/models/EventInfo.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/EventInfo.java
@@ -10,7 +10,6 @@ import org.gophillygo.app.R;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 public class EventInfo extends AttractionInfo<Event> {

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -14,6 +14,7 @@
         <import type="android.view.View"/>
     </data>
     <ScrollView
+        android:id="@+id/place_detail_scroll_view"
         android:fillViewport="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -221,7 +222,7 @@
                 app:layout_constraintTop_toBottomOf="@+id/place_detail_button_bar" />
 
             <android.support.v7.widget.RecyclerView
-                android:id="@+id/place_detail_list_recycler_view"
+                android:id="@+id/place_detail_events_recycler_view"
                 app:layout_constraintTop_toBottomOf="@+id/place_detail_watershed_alliance_icon"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -197,7 +197,6 @@
                     android:drawableStart="@drawable/ic_directions_blue_24dp"
                     android:onClick="@{activity::goToDirections}"
                     android:text="@string/place_detail_directions_button"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@+id/place_detail_website_button"
                     app:layout_constraintStart_toEndOf="@+id/place_detail_map_button" />
 
@@ -220,6 +219,13 @@
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/place_detail_button_bar" />
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/place_detail_list_recycler_view"
+                app:layout_constraintTop_toBottomOf="@+id/place_detail_watershed_alliance_icon"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+            </android.support.v7.widget.RecyclerView>
 
         </android.support.constraint.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_place_detail.xml
+++ b/app/src/main/res/layout/activity_place_detail.xml
@@ -224,6 +224,7 @@
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/place_detail_events_recycler_view"
                 app:layout_constraintTop_toBottomOf="@+id/place_detail_watershed_alliance_icon"
+                android:paddingTop="16dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             </android.support.v7.widget.RecyclerView>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -402,6 +402,7 @@
         <item name="android:layout_width">150dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
+        <item name="android:layout_marginBottom">16dp</item>
         <item name="android:adjustViewBounds">true</item>
         <item name="android:scaleType">centerInside</item>
         <item name="android:src">@drawable/watershed_alliance_full_icon_300x104px</item>


### PR DESCRIPTION
## Overview

Display list of related events inline in the place detail view, at the bottom.

## Demo

![screenshot_1531487965](https://user-images.githubusercontent.com/960264/42693705-f5965d78-867d-11e8-8215-e5b51c65e894.png)

## Testing

 - Click the calendar icon/related event count at the head of the detail view of a place with event(s)
 - Should scroll down to event list (if not already in view)
 - Toggling event user flags from the place detail view should work as expected
 - Clicking an event card from the detail view should go to the event detail

Closes #113 
