### PR TITLE
Geofence liked attractions

### DIFF
--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -205,8 +205,9 @@ public class EventDetailActivity extends AttractionDetailActivity {
     }
 
     private void updateFlag(int itemId) {
-        boolean haveExistingGeofence = eventInfo.getFlag().getOption()
-                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String option = eventInfo.getFlag().getOption().apiName;
+        boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                option.equals(AttractionFlag.Option.Liked.apiName);
         eventInfo.updateAttractionFlag(itemId);
 
         viewModel.updateAttractionFlag(eventInfo.getFlag(),
@@ -214,7 +215,9 @@ public class EventDetailActivity extends AttractionDetailActivity {
                 getString(R.string.user_flag_post_api_key),
                 UserUtils.isFlagPostingEnabled(this));
 
-        Boolean settingGeofence = eventInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String optionAfter = eventInfo.getFlag().getOption().apiName;
+        Boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                optionAfter.equals(AttractionFlag.Option.Liked.apiName);
         addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
         binding.notifyPropertyChanged(BR.destinationInfo);
     }

--- a/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
@@ -65,8 +65,9 @@ public class EventsListActivity extends FilterableListActivity
     }
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {
-        Boolean haveExistingGeofence = eventInfo.getFlag()
-                .getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String option = eventInfo.getFlag().getOption().apiName;
+        Boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                option.equals(AttractionFlag.Option.Liked.apiName);
 
         eventInfo.updateAttractionFlag(item.getItemId());
 
@@ -78,7 +79,9 @@ public class EventsListActivity extends FilterableListActivity
 
         // do not attempt to add a geofence for an event with no location
         if (((EventInfo)eventInfo).hasDestinationName()) {
-            Boolean settingGeofence = eventInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+            String optionAfter = eventInfo.getFlag().getOption().apiName;
+            Boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                    optionAfter.equals(AttractionFlag.Option.Liked.apiName);
             addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
         } else {
             // TODO: notify user?

--- a/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
@@ -159,8 +159,9 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
     public void optionsButtonClick(View view, T info) {
         PopupMenu menu = FlagMenuUtils.getFlagPopupMenu(this, view, info.getFlag());
         menu.setOnMenuItemClickListener(item -> {
-            Boolean haveExistingGeofence = info.getFlag().getOption()
-                    .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+            String option = info.getFlag().getOption().apiName;
+            Boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                    option.equals(AttractionFlag.Option.Liked.apiName);
 
             info.updateAttractionFlag(item.getItemId());
 
@@ -169,7 +170,9 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
 
             popupBinding.setAttractionInfo(info);
             popupBinding.setAttraction(info.getAttraction());
-            Boolean settingGeofence = info.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+            String optionAfter = info.getFlag().getOption().apiName;
+            Boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                    optionAfter.equals(AttractionFlag.Option.Liked.apiName);
             addOrRemoveGeofence(info, haveExistingGeofence, settingGeofence);
             return true;
         });

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -159,11 +159,14 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
             Crashlytics.log(message);
             return;
         }
-        Boolean haveExistingGeofence = destinationInfo.getFlag().getOption()
-                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String option = destinationInfo.getFlag().getOption().apiName;
+        boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                option.equals(AttractionFlag.Option.Liked.apiName);
         destinationInfo.updateAttractionFlag(itemId);
         destinationViewModel.updateAttractionFlag(destinationInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key), UserUtils.isFlagPostingEnabled(this));
-        Boolean settingGeofence = itemId  == AttractionFlag.Option.WantToGo.code;
+        String optionAfter = destinationInfo.getFlag().getOption().apiName;
+        boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                optionAfter.equals(AttractionFlag.Option.Liked.apiName);
         addOrRemoveGeofence(destinationInfo, haveExistingGeofence, settingGeofence);
         binding.notifyPropertyChanged(BR.destinationInfo);
     }
@@ -206,8 +209,9 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
     @Override
     public boolean clickedFlagOption(MenuItem item, AttractionInfo eventInfo, Integer position) {
         Log.d(LOG_LABEL, "clicked flag option on event at " + position);
-        Boolean haveExistingGeofence = eventInfo.getFlag()
-                .getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String option = eventInfo.getFlag().getOption().apiName;
+        boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                option.equals(AttractionFlag.Option.Liked.apiName);
 
         eventInfo.updateAttractionFlag(item.getItemId());
         eventViewModel.updateAttractionFlag(eventInfo.getFlag(), userUuid, getString(R.string.user_flag_post_api_key), UserUtils.isFlagPostingEnabled(this));
@@ -216,7 +220,9 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
         // do not attempt to add a geofence for an event with no location (should always exist here,
         // as we know there is an associated place)
         if (((EventInfo)eventInfo).hasDestinationName()) {
-            Boolean settingGeofence = eventInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+            String optionAfter = eventInfo.getFlag().getOption().apiName;
+            boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                    optionAfter.equals(AttractionFlag.Option.Liked.apiName);
             addOrRemoveGeofence(eventInfo, haveExistingGeofence, settingGeofence);
         }
 

--- a/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
@@ -69,8 +69,9 @@ public class PlacesListActivity extends FilterableListActivity implements
     }
 
     public boolean clickedFlagOption(MenuItem item, AttractionInfo destinationInfo, Integer position) {
-        Boolean haveExistingGeofence = destinationInfo.getFlag().getOption()
-                .apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String option = destinationInfo.getFlag().getOption().apiName;
+        boolean haveExistingGeofence = option.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                option.equals(AttractionFlag.Option.Liked.apiName);
 
         destinationInfo.updateAttractionFlag(item.getItemId());
 
@@ -80,7 +81,9 @@ public class PlacesListActivity extends FilterableListActivity implements
                 UserUtils.isFlagPostingEnabled(this));
 
         placesListAdapter.notifyItemChanged(position);
-        Boolean settingGeofence = destinationInfo.getFlag().getOption().apiName.equals(AttractionFlag.Option.WantToGo.apiName);
+        String optionAfter = destinationInfo.getFlag().getOption().apiName;
+        boolean settingGeofence = optionAfter.equals(AttractionFlag.Option.WantToGo.apiName) ||
+                optionAfter.equals(AttractionFlag.Option.Liked.apiName);
         addOrRemoveGeofence(destinationInfo, haveExistingGeofence, settingGeofence);
 	    return true;
     }

--- a/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
+++ b/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
@@ -157,8 +157,8 @@ public abstract class DestinationDao implements AttractionDao<Destination> {
 
     @Query(value = "SELECT destination.* FROM destination INNER JOIN attractionflag " +
             "ON destination._id = attractionflag.attraction_id AND attractionflag.is_event = 0 " +
-            "WHERE attractionflag.option = :geofenceFlagCode")
-    public abstract List<Destination> getGeofenceDestinations(int geofenceFlagCode);
+            "WHERE attractionflag.option = :wantToGoCode OR attractionflag.option = :likedCode")
+    public abstract List<Destination> getGeofenceDestinations(int wantToGoCode, int likedCode);
 
     /**
      * Get a single destination.

--- a/app/src/main/java/org/gophillygo/app/data/EventDao.java
+++ b/app/src/main/java/org/gophillygo/app/data/EventDao.java
@@ -76,8 +76,8 @@ public abstract class EventDao implements AttractionDao<Event> {
             "INNER JOIN destination ON destination._id = event.destination " +
             "LEFT JOIN attractionflag " +
             "ON event._id = attractionflag.attraction_id AND attractionflag.is_event = 1 " +
-            "WHERE attractionflag.option = :geofenceFlagCode")
-    public abstract List<EventInfo> getGeofenceEvents(int geofenceFlagCode);
+            "WHERE attractionflag.option = :wantToGoCode OR attractionflag.option = :likedCode")
+    public abstract List<EventInfo> getGeofenceEvents(int wantToGoCode, int likedCode);
 
     /**
      * Get event from background thread.

--- a/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
@@ -125,8 +125,10 @@ public class AddRemoveGeofencesBroadcastReceiver extends BroadcastReceiver {
                 @Override
                 protected Void doInBackground(Void... voids) {
                     List<Destination> destinations = destinationDao
-                            .getGeofenceDestinations(AttractionFlag.Option.WantToGo.code);
-                    List<EventInfo> events = eventDao.getGeofenceEvents(AttractionFlag.Option.WantToGo.code);
+                            .getGeofenceDestinations(AttractionFlag.Option.WantToGo.code,
+                                    AttractionFlag.Option.Liked.code);
+                    List<EventInfo> events = eventDao.getGeofenceEvents(AttractionFlag.Option.WantToGo.code,
+                            AttractionFlag.Option.Liked.code);
 
                     // Check that there is at least one place to geofence and prevent NPEs by
                     // initializing null lists

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,8 +100,8 @@
     <string name="user_uuid_shared_preferences_file">gophillygo_user_uuid_shared_preferences</string>
     <!-- the key to the UUID within the shared preferences file -->
     <string name="user_uuid_shared_preferences_key">gophillygo_user_uuid</string>
-    <string name="location_network_permission_rationale">Please set location mode to \"High Accuracy\" to receive notifications when places you want to go are nearby.</string>
-    <string name="channel_description">Nearby GoPhillyGo destinations you want to go visit</string>
+    <string name="location_network_permission_rationale">Please set location mode to \"High Accuracy\" to receive notifications when places you like or want to go are nearby.</string>
+    <string name="channel_description">Nearby GoPhillyGo destinations you like or want to go visit</string>
     <string name="place_nearby_notification">Are you visiting %1$s now? Learn more.</string>
     <string name="place_nearby_been_button">I\'m there now</string>
     <string name="home_grid_events">Upcoming events</string>
@@ -117,7 +117,7 @@
 
     <!-- settings -->
     <string name="general_preference_notifications">Notifications</string>
-    <string name="general_preference_notifications_summary">Notify me when I\'m near a place I want to go.</string>
+    <string name="general_preference_notifications_summary">Notify me when I\'m near a place I like or want to go.</string>
     <string name="general_preference_fabric_logging">Share crash and usage data</string>
     <string name="general_preference_fabric_logging_summary">Send anonymous reports about how I\'m using the app and when the app crashes.</string>
     <string name="general_preferences_fabric_logging_disabled_notification">Please restart app for setting change to take effect.</string>
@@ -141,7 +141,7 @@
     <string name="app_info_description">The Clean Air Council\'s GoPhillyGo mobile application highlights the greater Philadelphia area\'s best educational and recreational destinations and events.</string>
     <string name="app_info_root_site_link" translatable="false"><a href="https://gophillygo.org">GoPhillyGo website</a></string>
     <string name="app_info_blog_link" translatable="false"><a href="https://gophillygo.org/learn">GoPhillyGo blog</a></string>
-    
+
     <!-- First launch dialog -->
     <string name="first_launch_dialog_title">Help us improve</string>
     <string name="first_launch_dialog_message">May we collect anonymous usage and crash data from you to improve our app? You can always change this later under the settings.</string>


### PR DESCRIPTION
## Overview

Geofence places and events flagged both 'liked' and 'want to go.'

## Testing

(Log messages will tell if a geofence gets added or removed.)

 - Flagging a place as 'liked' should add a geofence
 - Geofences should also still work for places flagged 'want to go'
 - Changing the flag to another option should remove the geofence
 - Behavior should work as expected in all places where flag can be changed (event and place lists, details, and map)

Closes #129.