### PR TITLE
Rename watershed alliance

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     </plurals>
     <string name="accessible_filter_button_title">Wheelchair accessible</string>
 
-    <string name="watershed_alliance_label">Watershed Alliance</string>
+    <string name="watershed_alliance_label">Alliance for Watershed Education</string>
     <string name="bicycle_activity_label">Cycling</string>
 
     <string name="nature_category_label">Nature</string>


### PR DESCRIPTION
## Overview

Refer to watershed alliance as ' Alliance for Watershed Education'.

## Demo

![image](https://user-images.githubusercontent.com/960264/43157350-cc3bf9d0-8f4a-11e8-821d-7c6a1f50794b.png)

## Notes

Originally tried the full name ('' Alliance for Watershed Education of the Delaware River'), but it didn't fit well in the space.

Closes #147.