### PR TITLE
Disable extra large display support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,11 @@
     <!-- Listen for reboot to set up geofences again -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <supports-screens android:smallScreens="true"
+        android:normalScreens="true"
+        android:largeScreens="true"
+        android:xlargeScreens="false"/>
+
     <application
         android:name=".GoPhillyGoApp"
         android:allowBackup="true"


### PR DESCRIPTION
## Overview

Tablets over 7 inches do not display the toolbar properly.
Disable explicit app support for extra-large (>7") displays.

Since we have chosen to *not* support tablets for this project, making that decision an explicit configuration seems preferable to creating custom layout(s) for extra-large displays, which would then require support and separate maintenance from the standard layouts.

## Demo

#### Nexus 9 tablet emulator, with toolbar showing

![screenshot_1532626057](https://user-images.githubusercontent.com/960264/43278028-d1f88aee-90d7-11e8-95b1-7cb1af470d49.png)

## Testing

 - App should continue to run as before on 7" tablets and any device with a smaller display
 - On extra-large devices, such as a 9" tablet emulator, toolbar should display (scaled up)

Closes #152.