### PR TITLE
Feature/kak/remove been button#157

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,6 @@ dependencies {
 
     // Room
     implementation "android.arch.persistence.room:runtime:$roomVersion"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
     annotationProcessor "android.arch.persistence.room:compiler:$roomVersion"
 
     // Android UI libraries
@@ -98,7 +97,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
 
     // Android WorkManager
-    implementation 'android.arch.work:work-runtime:1.0.0-alpha04'
+    implementation 'android.arch.work:work-runtime:1.0.0-alpha06'
 
     // Carousel
     implementation 'com.synnapps:carouselview:0.1.5'

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -119,15 +119,6 @@ public class EventDetailActivity extends AttractionDetailActivity {
                     // Since we call `getDestination(...).observe(...)` every time the event is updated,
                     // we need to remove destination observer every time it is called
                     data.removeObservers(this);
-
-                    // Check if flag set by notification to mark event as "been" and set flag if so
-                    if (getIntent().hasExtra(GeofenceTransitionWorker.MARK_BEEN_KEY)) {
-                        if(getIntent().getBooleanExtra(GeofenceTransitionWorker.MARK_BEEN_KEY, false) &&
-                                !eventInfo.getFlag().getOption().id.equals(AttractionFlag.Option.Been.id)) {
-
-                            updateFlag(AttractionFlag.Option.Been.id);
-                        }
-                    }
                 });
             }
 

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -95,15 +95,6 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
 
             this.destinationInfo = destinationInfo;
 
-            // Check if flag set by notification to mark event as "been" and set flag if so
-            if (getIntent().hasExtra(GeofenceTransitionWorker.MARK_BEEN_KEY)) {
-                if(getIntent().getBooleanExtra(GeofenceTransitionWorker.MARK_BEEN_KEY, false) &&
-                        !destinationInfo.getFlag().getOption().id.equals(AttractionFlag.Option.Been.id)) {
-
-                    updateFlag(AttractionFlag.Option.Been.id);
-                }
-            }
-
             // set up data binding object
             binding.setDestination(destinationInfo.getDestination());
             binding.setDestinationInfo(destinationInfo);

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -153,9 +153,8 @@ public class GeofenceTransitionWorker extends Worker {
                                 .setAutoCancel(true) // close notification when tapped
                                 .setGroup(GROUP_ID)
                                 // alert for all notifications
-                                .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
-                                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                                .setGroupSummary(true);
+                                .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_ALL)
+                                .setPriority(NotificationCompat.PRIORITY_HIGH);
 
                         if (imageBitmap != null) {
                             notificationBuilder = notificationBuilder.setStyle(new NotificationCompat.BigPictureStyle()

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -30,13 +30,10 @@ import java.util.concurrent.ExecutionException;
 import androidx.work.Data;
 import androidx.work.Worker;
 
-import static org.gophillygo.app.activities.AttractionDetailActivity.GEOFENCE_ID_KEY;
-import static org.gophillygo.app.activities.AttractionDetailActivity.NOTIFICATION_ID_KEY;
 import static org.gophillygo.app.tasks.GeofenceTransitionBroadcastReceiver.GEOFENCE_IMAGES_KEY;
 
 public class GeofenceTransitionWorker extends Worker {
 
-    public static final String MARK_BEEN_KEY = "mark_been";
     public static final String HAS_ERROR_KEY = "has_error";
     public static final String ERROR_CODE_KEY = "error_code";
     public static final String TRANSITION_KEY = "transition";
@@ -56,7 +53,6 @@ public class GeofenceTransitionWorker extends Worker {
     private static final int NOTIFICATION_IMAGE_WIDTH = 1024;
     private static final int NOTIFICATION_IMAGE_HEIGHT = 512;
 
-    private static final int BEEN_PENDING_INTENT_CODE = 101;
     private static final int DETAIL_PENDING_INTENT_CODE = 102;
 
     @NonNull
@@ -127,24 +123,14 @@ public class GeofenceTransitionWorker extends Worker {
 
                     // Get intent for the detail view to open on notification click.
                     Intent intent;
-                    Intent beenIntent;
+
                     if (isEvent) {
                         intent = new Intent(context, EventDetailActivity.class);
                         intent.putExtra(EventDetailActivity.EVENT_ID_KEY, (long) geofenceId);
-                        beenIntent = new Intent(context, EventDetailActivity.class);
-                        beenIntent.putExtra(EventDetailActivity.EVENT_ID_KEY, (long) geofenceId);
                     } else {
                         intent = new Intent(context, PlaceDetailActivity.class);
                         intent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, (long) geofenceId);
-                        beenIntent = new Intent(context, PlaceDetailActivity.class);
-                        beenIntent.putExtra(PlaceDetailActivity.DESTINATION_ID_KEY, (long) geofenceId);
                     }
-
-                    // When opening detail activity from 'been' button, pass key to tell
-                    // activity to mark its model as 'been' and the notification ID, to close it
-                    beenIntent.putExtra(MARK_BEEN_KEY, true);
-                    beenIntent.putExtra(NOTIFICATION_ID_KEY, notificationTag);
-                    beenIntent.putExtra(GEOFENCE_ID_KEY, geofenceId);
 
                     // Add the intent to the stack builder, which inflates the back stack
                     TaskStackBuilder stackBuilder = TaskStackBuilder.create(context);
@@ -153,21 +139,12 @@ public class GeofenceTransitionWorker extends Worker {
                     PendingIntent resultPendingIntent =
                             stackBuilder.getPendingIntent(DETAIL_PENDING_INTENT_CODE, PendingIntent.FLAG_UPDATE_CURRENT);
 
-                    // Create pending intent for marking place "been"
-                    // Add the intent to the stack builder, which inflates the back stack
-                    TaskStackBuilder beenStackBuilder = TaskStackBuilder.create(context);
-                    beenStackBuilder.addNextIntentWithParentStack(beenIntent);
-                    // Get the PendingIntent containing the entire back stack
-                    PendingIntent beenPendingIntent =
-                            beenStackBuilder.getPendingIntent(BEEN_PENDING_INTENT_CODE, PendingIntent.FLAG_UPDATE_CURRENT);
-
                     // Show notification on UI thread
                     handler.post(() -> {
                         String nearbyNotice = context.getString(R.string.place_nearby_notification, placeName);
                         createNotificationChannel(context);
 
                         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID)
-                                // TODO: use app icon of some sort
                                 .setSmallIcon(R.drawable.ic_flag_blue_24dp)
                                 .setOnlyAlertOnce(false)
                                 .setContentTitle(placeName)
@@ -178,9 +155,6 @@ public class GeofenceTransitionWorker extends Worker {
                                 // alert for all notifications
                                 .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
                                 .setPriority(NotificationCompat.PRIORITY_HIGH)
-                                .addAction(R.drawable.ic_beenhere_blue_24dp,
-                                        context.getString(R.string.place_nearby_been_button),
-                                        beenPendingIntent)
                                 .setGroupSummary(true);
 
                         if (imageBitmap != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="user_uuid_shared_preferences_key">gophillygo_user_uuid</string>
     <string name="location_network_permission_rationale">Please set location mode to \"High Accuracy\" to receive notifications when places you like or want to go are nearby.</string>
     <string name="channel_description">Nearby GoPhillyGo destinations you like or want to go visit</string>
-    <string name="place_nearby_notification">Are you visiting %1$s now? Learn more.</string>
+    <string name="place_nearby_notification">You are near %1$s. Learn more.</string>
     <string name="place_nearby_been_button">I\'m there now</string>
     <string name="home_grid_events">Upcoming events</string>
     <string name="general_preference_category">General</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Overview

Removes 'been' action button from the geofencing notifications. Also updates a dependency minor version, and modifies the notification text message.

Also also: fixes an issue with fresh installs on Android P: the "high accuracy" location setting that must be set for geofencing to work on lower APIs, no longer exists in P and appears to no longer be necessary, so do not redirect user to app settings in that case. If app had not been installed before upgrading to P, this would cause the app to go to settings page on every launch.

## Demo

![screenshot_1533840845](https://user-images.githubusercontent.com/960264/44049446-21fe5568-9f02-11e8-9357-7a292d04b899.png)

## Testing

 - Trigger a geofencing notification in the emulator by sending coordinates near a place marked 'liked' or 'want to go'
 - Notification should have no actions at bottom, and check notification text

Closes #157.