### PR TITLE
Add been category to homescreen

### DIFF
--- a/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/HomeActivity.java
@@ -54,7 +54,6 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
-        Log.d(LOG_LABEL, "onCreate");
         categories = new ArrayList<>(CategoryAttraction.PlaceCategories.size());
 
         Toolbar toolbar = findViewById(R.id.home_toolbar);
@@ -94,7 +93,6 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
     @Override
     protected void onResume() {
         super.onResume();
-        Log.d(LOG_LABEL, "onResume");
         addScrollListener();
     }
 
@@ -226,6 +224,9 @@ PlaceCategoryGridAdapter.GridViewHolder.PlaceGridItemClickListener {
                 break;
             case WatershedAlliance:
                 filter.setWatershedAlliance(true);
+                break;
+            case Been:
+                filter.setBeen(true);
                 break;
             default:
                 Log.e(LOG_LABEL, "Unrecognized place category " + category.displayName);

--- a/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
+++ b/app/src/main/java/org/gophillygo/app/data/DestinationDao.java
@@ -130,6 +130,10 @@ public abstract class DestinationDao implements AttractionDao<Destination> {
 
         LiveData<CategoryImage> educational = getRandomExerciseImages();
         addSourceToRandomImagesLiveData(educational, CategoryAttraction.PlaceCategories.Educational, categoryAttractions, data);
+
+        LiveData<CategoryImage> been = getRandomImagesForFlag(AttractionFlag.Option.Been.code);
+        addSourceToRandomImagesLiveData(been, CategoryAttraction.PlaceCategories.Been, categoryAttractions, data);
+
         return data;
     }
 

--- a/app/src/main/java/org/gophillygo/app/data/models/CategoryAttraction.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/CategoryAttraction.java
@@ -56,7 +56,8 @@ public class CategoryAttraction {
         WatershedAlliance(3, R.string.watershed_alliance_label, WATERSHED_ALLIANCE),
         Nature(4, R.string.nature_category_label, NATURE_API_NAME),
         Exercise(5, R.string.exercise_category_label, EXERCISE_API_NAME),
-        Educational(6, R.string.educational_category_label, EDUCATIONAL_API_NAME);
+        Educational(6, R.string.educational_category_label, EDUCATIONAL_API_NAME),
+        Been(7, R.string.place_been_option, AttractionFlag.Option.Been.apiName);
 
         private static final SparseArray<PlaceCategories> map = new SparseArray<>();
         static {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Overview

Add 'been' category filter button to home screen.

## Demo

![screenshot_1534184921](https://user-images.githubusercontent.com/960264/44050618-77e062fc-9f05-11e8-8100-7c7d0e0f4231.png)

## Testing

 - Mark at least one place or event as 'been'
 - On home screen display, the last category filter link should be for 'been'
 - Clicking filter button should go to appropriately filtered list

Closes #158.