### PR TITLE
Hide destination for events with multiple destinations

### DIFF
--- a/app/schemas/org.gophillygo.app.data.GpgDatabase/15.json
+++ b/app/schemas/org.gophillygo.app.data.GpgDatabase/15.json
@@ -1,0 +1,553 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "b560421892488ec3c31b4256e8110747",
+    "entities": [
+      {
+        "tableName": "AttractionFlag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`attraction_id` INTEGER NOT NULL, `is_event` INTEGER NOT NULL, `option` INTEGER, PRIMARY KEY(`attraction_id`, `is_event`))",
+        "fields": [
+          {
+            "fieldPath": "attractionID",
+            "columnName": "attraction_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "option",
+            "columnName": "option",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "attraction_id",
+            "is_event"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_AttractionFlag_is_event_option",
+            "unique": false,
+            "columnNames": [
+              "is_event",
+              "option"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AttractionFlag_is_event_option` ON `${TABLE_NAME}` (`is_event`, `option`)"
+          },
+          {
+            "name": "index_AttractionFlag_attraction_id",
+            "unique": false,
+            "columnNames": [
+              "attraction_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AttractionFlag_attraction_id` ON `${TABLE_NAME}` (`attraction_id`)"
+          },
+          {
+            "name": "index_AttractionFlag_is_event",
+            "unique": false,
+            "columnNames": [
+              "is_event"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AttractionFlag_is_event` ON `${TABLE_NAME}` (`is_event`)"
+          },
+          {
+            "name": "index_AttractionFlag_option",
+            "unique": false,
+            "columnNames": [
+              "option"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AttractionFlag_option` ON `${TABLE_NAME}` (`option`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Destination",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT, `state` TEXT, `address` TEXT, `categories` TEXT, `watershed_alliance` INTEGER NOT NULL, `zipcode` TEXT, `distance` REAL NOT NULL, `_id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, `nature` INTEGER, `exercise` INTEGER, `educational` INTEGER, `x` REAL, `y` REAL, `street_address` TEXT, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categories",
+            "columnName": "categories",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watershedAlliance",
+            "columnName": "watershed_alliance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipCode",
+            "columnName": "zipcode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "distance",
+            "columnName": "distance",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryFlags.nature",
+            "columnName": "nature",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categoryFlags.exercise",
+            "columnName": "exercise",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "categoryFlags.educational",
+            "columnName": "educational",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.x",
+            "columnName": "x",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.y",
+            "columnName": "y",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "attributes.streetAddress",
+            "columnName": "street_address",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Destination_educational",
+            "unique": false,
+            "columnNames": [
+              "educational"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_educational` ON `${TABLE_NAME}` (`educational`)"
+          },
+          {
+            "name": "index_Destination_nature",
+            "unique": false,
+            "columnNames": [
+              "nature"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_nature` ON `${TABLE_NAME}` (`nature`)"
+          },
+          {
+            "name": "index_Destination_exercise",
+            "unique": false,
+            "columnNames": [
+              "exercise"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_exercise` ON `${TABLE_NAME}` (`exercise`)"
+          },
+          {
+            "name": "index_Destination_watershed_alliance",
+            "unique": false,
+            "columnNames": [
+              "watershed_alliance"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_watershed_alliance` ON `${TABLE_NAME}` (`watershed_alliance`)"
+          },
+          {
+            "name": "index_Destination_distance",
+            "unique": false,
+            "columnNames": [
+              "distance"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_distance` ON `${TABLE_NAME}` (`distance`)"
+          },
+          {
+            "name": "index_Destination__id",
+            "unique": false,
+            "columnNames": [
+              "_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination__id` ON `${TABLE_NAME}` (`_id`)"
+          },
+          {
+            "name": "index_Destination_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Destination_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Destination_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Destination_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Destination_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Destination_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destination` INTEGER, `destinations` TEXT, `start_date` TEXT, `end_date` TEXT, `_id` INTEGER NOT NULL, `placeID` INTEGER NOT NULL, `name` TEXT, `accessible` INTEGER NOT NULL, `image` TEXT, `cycling` INTEGER NOT NULL, `description` TEXT, `priority` INTEGER NOT NULL, `activities` TEXT, `website_url` TEXT, `wide_image` TEXT, `is_event` INTEGER NOT NULL, `extra_wide_images` TEXT, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`_id`), FOREIGN KEY(`destination`) REFERENCES `Destination`(`_id`) ON UPDATE NO ACTION ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "destinations",
+            "columnName": "destinations",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "placeID",
+            "columnName": "placeID",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accessible",
+            "columnName": "accessible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cycling",
+            "columnName": "cycling",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activities",
+            "columnName": "activities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "websiteUrl",
+            "columnName": "website_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wideImage",
+            "columnName": "wide_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEvent",
+            "columnName": "is_event",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extraWideImages",
+            "columnName": "extra_wide_images",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Event_destination",
+            "unique": false,
+            "columnNames": [
+              "destination"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_destination` ON `${TABLE_NAME}` (`destination`)"
+          },
+          {
+            "name": "index_Event_start_date",
+            "unique": false,
+            "columnNames": [
+              "start_date"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_start_date` ON `${TABLE_NAME}` (`start_date`)"
+          },
+          {
+            "name": "index_Event_end_date",
+            "unique": false,
+            "columnNames": [
+              "end_date"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_end_date` ON `${TABLE_NAME}` (`end_date`)"
+          },
+          {
+            "name": "index_Event__id",
+            "unique": false,
+            "columnNames": [
+              "_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event__id` ON `${TABLE_NAME}` (`_id`)"
+          },
+          {
+            "name": "index_Event_placeID",
+            "unique": false,
+            "columnNames": [
+              "placeID"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_placeID` ON `${TABLE_NAME}` (`placeID`)"
+          },
+          {
+            "name": "index_Event_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_Event_accessible",
+            "unique": false,
+            "columnNames": [
+              "accessible"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_accessible` ON `${TABLE_NAME}` (`accessible`)"
+          },
+          {
+            "name": "index_Event_cycling",
+            "unique": false,
+            "columnNames": [
+              "cycling"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_cycling` ON `${TABLE_NAME}` (`cycling`)"
+          },
+          {
+            "name": "index_Event_activities",
+            "unique": false,
+            "columnNames": [
+              "activities"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Event_activities` ON `${TABLE_NAME}` (`activities`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Destination",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "destination"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b560421892488ec3c31b4256e8110747')"
+    ]
+  }
+}

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -104,6 +104,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
             }
 
             this.eventInfo = eventInfo;
+
             Integer destinationId = eventInfo.getEvent().getDestination();
             if (destinationId != null) {
                 LiveData<DestinationInfo> data = destinationViewModel.getDestination(destinationId);

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -121,6 +121,9 @@ public class EventDetailActivity extends AttractionDetailActivity {
                     // we need to remove destination observer every time it is called
                     data.removeObservers(this);
                 });
+            } else if (eventInfo.getEvent().getDestinations().size() > 1) {
+                // show message that their are multiple destinations
+                binding.setMultipleDestinations(true);
             }
 
             // set up data binding object
@@ -136,6 +139,13 @@ public class EventDetailActivity extends AttractionDetailActivity {
     // open website for event in browser
     public void goToWebsite(View view) {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(eventInfo.getEvent().getWebsiteUrl()));
+        startActivity(intent);
+    }
+
+    // Go to the GoPhillyGo details page for the event
+    public void goToDetailsPage(View view) {
+        String url = getString(R.string.website_host) + "/event/" + eventId + "/";
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         startActivity(intent);
     }
 

--- a/app/src/main/java/org/gophillygo/app/adapters/EventsListAdapter.java
+++ b/app/src/main/java/org/gophillygo/app/adapters/EventsListAdapter.java
@@ -3,11 +3,13 @@ package org.gophillygo.app.adapters;
 import android.content.Context;
 
 import org.gophillygo.app.R;
+import org.gophillygo.app.data.models.Destination;
 import org.gophillygo.app.data.models.Event;
 import org.gophillygo.app.data.models.EventInfo;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -34,6 +36,11 @@ public class EventsListAdapter extends AttractionListAdapter<EventInfo> {
         super(context, attractions, R.layout.event_list_item, listener);
         this.context = context;
         now = new Date();
+    }
+
+    public boolean hasMultipleDestinations(Event event) {
+        ArrayList<Destination> destinations = event.getDestinations();
+        return destinations != null && destinations.size() > 1;
     }
 
     public boolean isCurrentlyOngoingEvent(Event event) {

--- a/app/src/main/java/org/gophillygo/app/data/GpgDatabase.java
+++ b/app/src/main/java/org/gophillygo/app/data/GpgDatabase.java
@@ -8,7 +8,7 @@ import org.gophillygo.app.data.models.AttractionFlag;
 import org.gophillygo.app.data.models.Destination;
 import org.gophillygo.app.data.models.Event;
 
-@Database(version=14, entities={AttractionFlag.class, Destination.class, Event.class})
+@Database(version=15, entities={AttractionFlag.class, Destination.class, Event.class})
 @TypeConverters({RoomConverters.class})
 public abstract class GpgDatabase extends RoomDatabase {
     abstract public DestinationDao destinationDao();

--- a/app/src/main/java/org/gophillygo/app/data/RoomConverters.java
+++ b/app/src/main/java/org/gophillygo/app/data/RoomConverters.java
@@ -5,6 +5,8 @@ import androidx.room.TypeConverter;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import org.gophillygo.app.data.models.Destination;
+
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 
@@ -19,6 +21,17 @@ public class RoomConverters {
 
     @TypeConverter
     public static String arraylistToString(ArrayList<String> list) {
+        return new Gson().toJson(list);
+    }
+
+    @TypeConverter
+    public static ArrayList<Destination> fromDestination(String value) {
+        Type listType = new TypeToken<ArrayList<Destination>>() {}.getType();
+        return new Gson().fromJson(value, listType);
+    }
+
+    @TypeConverter
+    public static String arraylistToDestination(ArrayList<Destination> list) {
         return new Gson().toJson(list);
     }
 }

--- a/app/src/main/java/org/gophillygo/app/data/models/Attraction.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/Attraction.java
@@ -31,7 +31,7 @@ public class Attraction {
     private final int _id;
 
     @ColumnInfo(index = true)
-    private final int placeID;
+    private int placeID;
 
     @ColumnInfo(index = true)
     private final String name;
@@ -128,6 +128,10 @@ public class Attraction {
 
     public int getPlaceID() {
         return placeID;
+    }
+
+    public void setPlaceID(int placeID) {
+        this.placeID = placeID;
     }
 
     public String getName() {

--- a/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -16,6 +16,7 @@ import org.gophillygo.app.data.models.DestinationCategories;
 import org.gophillygo.app.data.models.DestinationQueryResponse;
 import org.gophillygo.app.data.models.Event;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -74,6 +75,11 @@ abstract public class AttractionNetworkBoundResource<A extends Attraction, I ext
         for (Event item: response.getEvents()) {
             // Work-around for published event with unpublished destination
             if (item.getDestination() != null && !destinationIds.contains(item.getDestination())) {
+                item.setDestination(null);
+            }
+            // Hide (first) destination for events with multiple destinations
+            ArrayList<Destination> eventDestinations = item.getDestinations();
+            if (eventDestinations != null && eventDestinations.size() > 1) {
                 item.setDestination(null);
             }
             item.setTimestamp(timestamp);

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -55,7 +55,7 @@
                     android:layout_height="wrap_content"
                     android:text='@{@string/distance_with_abbreviated_miles(eventInfo.getFormattedDistance())}'
                     android:visibility="@{eventInfo.distance != null ? View.VISIBLE : View.GONE}"
-                    app:layout_constraintBottom_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -9,6 +9,7 @@
         <variable name="event" type="org.gophillygo.app.data.models.Event"/>
         <variable name="eventInfo" type="org.gophillygo.app.data.models.EventInfo"/>
         <variable name="destination" type="org.gophillygo.app.data.models.Destination"/>
+        <variable name="multipleDestinations" type="boolean"/>
         <variable name="attractionInfo" type="org.gophillygo.app.data.models.AttractionInfo"/>
         <variable name="activity" type="org.gophillygo.app.activities.EventDetailActivity" />
         <variable name="context" type="android.content.Context" />
@@ -54,7 +55,7 @@
                     android:layout_height="wrap_content"
                     android:text='@{@string/distance_with_abbreviated_miles(eventInfo.getFormattedDistance())}'
                     android:visibility="@{eventInfo.distance != null ? View.VISIBLE : View.GONE}"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintBottom_toTopOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -90,7 +91,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/event_detail_date_label" />
 
-
             <include
                 android:id="@+id/event_detail_description_card"
                 layout="@layout/detail_description"
@@ -104,6 +104,30 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/event_detail_destination_name" />
 
+            <TextView
+                android:id="@+id/event_detail_multiple_destinations_label"
+                style="@style/EventDetailLocation"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/event_detail_multiple_locations_label"
+                android:visibility="@{multipleDestinations ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toTopOf="@id/event_detail_multiple_destinations_link"
+                app:layout_constraintTop_toBottomOf="@id/event_detail_description_card"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/event_detail_multiple_destinations_link"
+                style="@style/BorderlessDetailButton"
+                android:drawableStart="@drawable/ic_public_blue_24dp"
+                android:onClick="@{activity::goToDetailsPage}"
+                android:text="@string/event_detail_multiple_locations_link"
+                android:visibility="@{multipleDestinations ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toTopOf="@id/event_detail_flag_options_card"
+                app:layout_constraintTop_toBottomOf="@id/event_detail_multiple_destinations_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
             <androidx.cardview.widget.CardView
                 android:id="@+id/event_detail_flag_options_card"
                 style="@style/ItemDetailOptionsCard"
@@ -111,7 +135,7 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/event_detail_description_card">
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_multiple_destinations_link">
 
                 <TextView
                     android:id="@+id/event_options_flag_text"

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -78,6 +78,21 @@
                 app:layout_constraintTop_toBottomOf="@+id/event_detail_carousel" />
 
             <TextView
+                android:id="@+id/event_detail_multiple_destinations_link"
+                style="@style/EventDetailMultipleLocations"
+                android:onClick="@{activity::goToDetailsPage}"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/event_multiple_locations_label"
+                android:visibility="@{multipleDestinations ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toTopOf="@id/event_detail_destination_name"
+                app:layout_constraintTop_toBottomOf="@id/event_detail_date_label"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <TextView
                 android:id="@+id/event_detail_destination_name"
                 style="@style/EventDetailLocation"
                 android:layout_width="0dp"
@@ -89,7 +104,7 @@
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/event_detail_date_label" />
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_multiple_destinations_link" />
 
             <include
                 android:id="@+id/event_detail_description_card"
@@ -104,30 +119,6 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/event_detail_destination_name" />
 
-            <TextView
-                android:id="@+id/event_detail_multiple_destinations_label"
-                style="@style/EventDetailLocation"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/event_detail_multiple_locations_label"
-                android:visibility="@{multipleDestinations ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toTopOf="@id/event_detail_multiple_destinations_link"
-                app:layout_constraintTop_toBottomOf="@id/event_detail_description_card"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/event_detail_multiple_destinations_link"
-                style="@style/BorderlessDetailButton"
-                android:drawableStart="@drawable/ic_public_blue_24dp"
-                android:onClick="@{activity::goToDetailsPage}"
-                android:text="@string/event_detail_multiple_locations_link"
-                android:visibility="@{multipleDestinations ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toTopOf="@id/event_detail_flag_options_card"
-                app:layout_constraintTop_toBottomOf="@id/event_detail_multiple_destinations_label"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
             <androidx.cardview.widget.CardView
                 android:id="@+id/event_detail_flag_options_card"
                 style="@style/ItemDetailOptionsCard"
@@ -135,7 +126,7 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/event_detail_multiple_destinations_link">
+                app:layout_constraintTop_toBottomOf="@+id/event_detail_description_card">
 
                 <TextView
                     android:id="@+id/event_options_flag_text"

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -66,8 +66,8 @@
             style="@style/EventListItemDestination"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@{attractionInfo.destinationName}"
-            android:visibility="@{attractionInfo.hasDestinationName ? View.VISIBLE : View.INVISIBLE}"
+            android:text="@{adapter.hasMultipleDestinations(attraction) ? @string/event_multiple_locations_label : attractionInfo.destinationName}"
+            android:visibility="@{attractionInfo.hasDestinationName || adapter.hasMultipleDestinations(attraction) ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/event_list_item_name_label" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">GoPhillyGo</string>
+    <string name="website_host" translatable="false">https://gophillygo.org</string>
 
     <!-- menu action titles -->
     <string name="menu_search_action">Search</string>
@@ -70,6 +71,9 @@
 
     <!-- event details -->
     <string name="event_details_been_want_to_go_label">Want to go?</string>
+
+    <string name="event_detail_multiple_locations_label">This event has multiple destinations.</string>
+    <string name="event_detail_multiple_locations_link">LEARN MORE</string>
 
     <string name="event_detail_map_button">Map</string>
     <string name="event_detail_directions_button">Directions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,11 +69,11 @@
     <string name="place_detail_directions_button">Directions</string>
     <string name="place_detail_website_button">Website</string>
 
+    <!-- event list and details -->
+    <string name="event_multiple_locations_label">Multiple destinations</string>
+
     <!-- event details -->
     <string name="event_details_been_want_to_go_label">Want to go?</string>
-
-    <string name="event_detail_multiple_locations_label">This event has multiple destinations.</string>
-    <string name="event_detail_multiple_locations_link">LEARN MORE</string>
 
     <string name="event_detail_map_button">Map</string>
     <string name="event_detail_directions_button">Directions</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -304,6 +304,10 @@
         <item name="android:padding">0dp</item>
     </style>
 
+    <style name="EventDetailMultipleLocations" parent="EventDetailLocation">
+        <item name="android:textColor">@color/color_primary</item>
+    </style>
+
     <style name="PlaceListItemName" parent="GpgTextAppearanceTitle">
         <item name="android:layout_marginStart">8dp</item>
         <item name="android:layout_marginEnd">8dp</item>


### PR DESCRIPTION
## Overview

Hide the destination for events that have multiple destinations.

Instead, show a message indicating that the event has multiple destinations, and link to the website details page.

## Demo

![image](https://user-images.githubusercontent.com/960264/69469669-15ae7e00-0d60-11ea-9ce6-d7e82cfc1468.png)

Destination not listed on event in list view:
![image](https://user-images.githubusercontent.com/960264/69469692-2bbc3e80-0d60-11ea-922e-25b0d9f23b5e.png)


## Notes

Since we are not fully implementing the new tours and multiple-destination events features in the Android app, instead we're simply hiding the destination from events that have more than one.

The old `destination` property is still present on the API response, and corresponds to the first destination when there are multiple.

## Testing

Testing this will require using the staging endpoint. Note that the one event currently on staging with multiple destinations is the one pictured above ("We Walk PHL in the Woodlands").

 - Modify the `WEBSERVICE_URL` in `DestinationWebservice.java` [here](https://github.com/azavea/cac-tripplanner-android/blob/develop/app/src/main/java/org/gophillygo/app/data/DestinationWebservice.java#L22) to point to https://staging.gophillygo.org/.
 - Also modify the `website_host` string added to `strings.xml` here to point to staging (used to link out to the event details page).
 - Install and run app
 - Go to events list
 - Destination should not be listed for event with multiple destinations
 - Tap to go to details for event with multiple destinations
 - Should see extra section noting multiple destinations, with a link
 - Link should go to event details page on the site
 - Other events (with one or no destination) should not display the new section


Closes #173.