### PR TITLE
Switch Crashlytics SDK

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://maven.google.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven4" />
+      <option name="name" value="maven4" />
+      <option name="url" value="https://maven.fabric.io/public" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Edit each to set the Android Maps key for both build flavors. See the comments i
 
 Also edit to set the server API key for posting user flags.
 
-Copy the example file for the Crashlytics/Fabric configuration and set the API key and secret.
-These can be found under the [organization settings](https://www.fabric.io/settings/organizations).
-
- - `cp example/fabric.properties app/fabric.properties`
-
-
 Configure Firebase for the crash reporting plugin to function. The Firebase configuration file can be found under the [Firebase console](https://console.firebase.google.com). Copy the `google-services.json` Firebase configuration file to the `app` directory.
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,8 +78,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Firebase
-    implementation 'com.google.firebase:firebase-crashlytics:17.0.1'
-    implementation 'com.google.firebase:firebase-analytics:17.4.3'
+    implementation 'com.google.firebase:firebase-crashlytics:17.1.1'
+    implementation 'com.google.firebase:firebase-analytics:17.4.4'
 
     // multidex
     implementation 'com.android.support:multidex:2.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Firebase
-    implementation 'com.google.firebase:firebase-core:17.4.3'
     implementation 'com.google.firebase:firebase-crashlytics:17.0.1'
     implementation 'com.google.firebase:firebase-analytics:17.4.3'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ repositories {
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     lintOptions {
@@ -31,14 +31,18 @@ android {
     signingConfigs {
         release
     }
+    buildFeatures {
+        dataBinding = true
+    }
     compileSdkVersion 29
     defaultConfig {
         applicationId "org.gophillygo.app"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 19
-        versionName "1.2.5"
+        versionCode 20
+        versionName "1.2.6"
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {
             annotationProcessorOptions {
@@ -63,9 +67,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    dataBinding {
-        enabled = true
-    }
     aaptOptions {
         cruncherEnabled = false
     }
@@ -77,8 +78,12 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Firebase
-    implementation 'com.google.firebase:firebase-core:17.2.2'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-core:17.4.3'
+    implementation 'com.google.firebase:firebase-crashlytics:17.0.1'
+    implementation 'com.google.firebase:firebase-analytics:17.4.3'
+
+    // multidex
+    implementation 'com.android.support:multidex:2.0.1'
 
     // ViewModel and LiveData
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
@@ -87,15 +92,15 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.3'
-    annotationProcessor 'androidx.room:room-compiler:2.2.3'
+    implementation 'androidx.room:room-runtime:2.2.5'
+    annotationProcessor 'androidx.room:room-compiler:2.2.5'
 
     // Android UI libraries
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.3.0-alpha01'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "androidx.preference:preference:1.1.0"
+    implementation "androidx.preference:preference:1.1.1"
 
     // Android Play services libraries
     implementation "com.google.android.gms:play-services-location:17.0.0"
@@ -108,29 +113,29 @@ dependencies {
     implementation 'com.synnapps:carouselview:0.1.5'
 
     // Badges
-    implementation 'com.github.nekocode:Badge:2.0'
+    implementation 'com.github.nekocode:Badge:2.1'
 
     // Glide
-    implementation('com.github.bumptech.glide:glide:4.10.0-SNAPSHOT') {
+    implementation('com.github.bumptech.glide:glide:4.11.0') {
         exclude group: "com.android.support"
     }
-    implementation("com.github.bumptech.glide:recyclerview-integration:4.10.0-SNAPSHOT") {
+    implementation("com.github.bumptech.glide:recyclerview-integration:4.11.0") {
         transitive = false
     }
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0-SNAPSHOT'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
 
     // Retrofit
-    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
 
     // Gson converter for Retrofit
-    implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
     // Okio log interceptor
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.7.2'
 
     // Dagger 2
-    def daggerVersion = '2.15'
+    def daggerVersion = '2.28'
     implementation "com.google.dagger:dagger:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation "com.google.dagger:dagger-android:$daggerVersion"
@@ -150,7 +155,7 @@ dependencies {
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
 
     // Test helpers for Room
-    testImplementation 'androidx.room:room-testing:2.2.3'
+    testImplementation 'androidx.room:room-testing:2.2.5'
 }
 
 if (project.file("release.properties").exists()) {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,20 +35,36 @@
 }
 
 ## Retrofit
-# Platform calls Class.forName on types which do not exist on Android to determine platform.
--dontnote retrofit2.Platform
-# Platform used when running on Java 8 VMs. Will not be used at runtime.
--dontwarn retrofit2.Platform$Java8
-# Retain generic type information for use by reflection by converters and adapters.
--keepattributes Signature
-# Retain declared checked exceptions for use by a Proxy instance.
--keepattributes Exceptions
+# https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
 
-## Okio (used by Retrofit)
--keep class okhttp3.** { *; }
--keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
--dontwarn okio.**
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
 
 ## Dagger
 -dontwarn com.google.errorprone.annotations.*

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
     <!-- Listen for reboot to set up geofences again -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Disable Crashlytics reporting here so it can be enabled in code as an opt-in -->
+    <meta-data
+        android:name="firebase_crashlytics_collection_enabled"
+        android:value="false" />
+
     <supports-screens android:smallScreens="true"
         android:normalScreens="true"
         android:largeScreens="true"

--- a/app/src/main/java/org/gophillygo/app/DetailCarouselViewListener.java
+++ b/app/src/main/java/org/gophillygo/app/DetailCarouselViewListener.java
@@ -1,9 +1,10 @@
 package org.gophillygo.app;
 
 import android.app.Activity;
-import androidx.databinding.DataBindingUtil;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.databinding.DataBindingUtil;
 
 import com.synnapps.carouselview.ViewListener;
 

--- a/app/src/main/java/org/gophillygo/app/FilterDialog.java
+++ b/app/src/main/java/org/gophillygo/app/FilterDialog.java
@@ -2,13 +2,13 @@ package org.gophillygo.app;
 
 import android.app.Dialog;
 import android.content.DialogInterface;
-
-import androidx.annotation.NonNull;
-import androidx.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.DataBindingUtil;
 
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 

--- a/app/src/main/java/org/gophillygo/app/FilterDialog.java
+++ b/app/src/main/java/org/gophillygo/app/FilterDialog.java
@@ -14,6 +14,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import org.gophillygo.app.data.models.Filter;
 import org.gophillygo.app.databinding.FilterModalBinding;
+import org.jetbrains.annotations.NotNull;
 
 
 public class FilterDialog extends BottomSheetDialogFragment {
@@ -39,7 +40,7 @@ public class FilterDialog extends BottomSheetDialogFragment {
     }
 
     @Override
-    public void onDismiss(DialogInterface dialog) {
+    public void onDismiss(@NotNull DialogInterface dialog) {
         Log.d(LOG_LABEL, "Selected " + filter.count() + " filters.");
         FilterChangeListener listener = (FilterChangeListener) getActivity();
         if (listener != null) {

--- a/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
@@ -55,13 +55,16 @@ public class GoPhillyGoApp extends Application implements HasAndroidInjector {
             Log.d(LOG_LABEL, "++++++++++++++++++++++++++++++++++++++++++++");
             Log.d(LOG_LABEL, "Crashlytics reporting is enabled");
             Log.d(LOG_LABEL, "++++++++++++++++++++++++++++++++++++++++++++");
+
+            // Only initialize Firebase if crash logging is enabled,
+            // so crash logs do not accumulate on the device instead.
+            FirebaseApp.initializeApp(this);
         } else {
             Log.d(LOG_LABEL, "----------------------------------------------");
             Log.d(LOG_LABEL, "Crashlytics reporting is disabled");
             Log.d(LOG_LABEL, "----------------------------------------------");
         }
 
-        FirebaseApp.initializeApp(this);
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
     }
 

--- a/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
@@ -3,6 +3,7 @@ package org.gophillygo.app;
 import android.app.Application;
 import android.util.Log;
 
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.di.AppInjector;
@@ -41,14 +42,27 @@ public class GoPhillyGoApp extends Application implements HasAndroidInjector {
             Log.d(LOG_LABEL, "Running in debug mode");
         }
 
-        // Initialize Firebase Crashlytics crash and usage data logging.
-        // Disable if user setting turned off
-        boolean enableAnalytics = UserUtils.isCrashlyticsEnabled(this);
-        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
 
         // Lazy initialization to support injection for content provider. See:
         // https://github.com/google/dagger/blob/master/java/dagger/android/DaggerApplication.java
         injectIfNecessary();
+
+        // Initialize Firebase Crashlytics crash and usage data logging.
+        // Disable if user setting turned off
+        boolean enableAnalytics = UserUtils.isCrashlyticsEnabled(this);
+
+        if (enableAnalytics) {
+            Log.d(LOG_LABEL, "++++++++++++++++++++++++++++++++++++++++++++");
+            Log.d(LOG_LABEL, "Crashlytics reporting is enabled");
+            Log.d(LOG_LABEL, "++++++++++++++++++++++++++++++++++++++++++++");
+        } else {
+            Log.d(LOG_LABEL, "----------------------------------------------");
+            Log.d(LOG_LABEL, "Crashlytics reporting is disabled");
+            Log.d(LOG_LABEL, "----------------------------------------------");
+        }
+
+        FirebaseApp.initializeApp(this);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
     }
 
     /**

--- a/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
@@ -46,7 +46,7 @@ public class GoPhillyGoApp extends Application implements HasAndroidInjector {
 
         // Initialize Firebase Crashlytics crash and usage data logging.
         // Disable if user setting turned off
-        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        boolean enableAnalytics = UserUtils.isCrashlyticsEnabled(this);
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
 
         // Lazy initialization to support injection for content provider. See:

--- a/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
@@ -1,9 +1,6 @@
 package org.gophillygo.app;
 
-import android.app.Activity;
 import android.app.Application;
-import android.content.BroadcastReceiver;
-import android.content.ContentProvider;
 import android.util.Log;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;

--- a/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
+++ b/app/src/main/java/org/gophillygo/app/GoPhillyGoApp.java
@@ -6,8 +6,7 @@ import android.content.BroadcastReceiver;
 import android.content.ContentProvider;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.di.AppInjector;
 import org.gophillygo.app.utils.UserUtils;
@@ -16,11 +15,8 @@ import javax.inject.Inject;
 
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
-import dagger.android.HasActivityInjector;
-import dagger.android.HasBroadcastReceiverInjector;
-import dagger.android.HasContentProviderInjector;
+import dagger.android.HasAndroidInjector;
 import dagger.android.support.DaggerApplication;
-import io.fabric.sdk.android.Fabric;
 
 /**
  * Based on:
@@ -28,21 +24,15 @@ import io.fabric.sdk.android.Fabric;
  */
 
 
-public class GoPhillyGoApp extends Application implements HasActivityInjector, HasBroadcastReceiverInjector, HasContentProviderInjector {
+public class GoPhillyGoApp extends Application implements HasAndroidInjector {
+
+
 
     private static final String LOG_LABEL = "GPGApp";
 
     @SuppressWarnings("WeakerAccess")
     @Inject
-    DispatchingAndroidInjector<Activity> dispatchingAndroidInjector;
-
-    @SuppressWarnings("WeakerAccess")
-    @Inject
-    DispatchingAndroidInjector<BroadcastReceiver> broadcastReceiverInjector;
-
-    @SuppressWarnings("WeakerAccess")
-    @Inject
-    DispatchingAndroidInjector<ContentProvider> contentProviderInjector;
+    DispatchingAndroidInjector<Object> dispatchingInjector;
 
     private volatile boolean needToInject = true;
 
@@ -54,12 +44,10 @@ public class GoPhillyGoApp extends Application implements HasActivityInjector, H
             Log.d(LOG_LABEL, "Running in debug mode");
         }
 
-        // Initialize Fabric/Crashlytics crash and usage data logging.
-        // Disable if user setting turned off; still must be initialized to avoid errors.
-        // Based on: https://stackoverflow.com/a/31996615
-        CrashlyticsCore core = new CrashlyticsCore.Builder()
-                .disabled(UserUtils.isFabricDisabled(this)).build();
-        Fabric.with(this, new Crashlytics.Builder().core(core).build());
+        // Initialize Firebase Crashlytics crash and usage data logging.
+        // Disable if user setting turned off
+        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
 
         // Lazy initialization to support injection for content provider. See:
         // https://github.com/google/dagger/blob/master/java/dagger/android/DaggerApplication.java
@@ -95,18 +83,8 @@ public class GoPhillyGoApp extends Application implements HasActivityInjector, H
     }
 
     @Override
-    public DispatchingAndroidInjector<Activity> activityInjector() {
-        return dispatchingAndroidInjector;
-    }
-
-    @Override
-    public AndroidInjector<BroadcastReceiver> broadcastReceiverInjector() {
-        return broadcastReceiverInjector;
-    }
-
-    @Override
-    public AndroidInjector<ContentProvider> contentProviderInjector() {
+    public AndroidInjector<Object> androidInjector() {
         injectIfNecessary();
-        return contentProviderInjector;
+        return dispatchingInjector;
     }
 }

--- a/app/src/main/java/org/gophillygo/app/GpgToggleButton.java
+++ b/app/src/main/java/org/gophillygo/app/GpgToggleButton.java
@@ -28,7 +28,7 @@ public class GpgToggleButton extends CompoundButton {
     }
 
 
-    @BindingAdapter("app:onCheckedChanged")
+    @BindingAdapter("onCheckedChanged")
     public static void setOnCheckedChanged(CompoundButton button, OnCheckedChangeListener listener) {
         Log.d(LOG_LABEL, "setOnCheckedChanged is setting the listener");
         button.setOnCheckedChangeListener(listener);

--- a/app/src/main/java/org/gophillygo/app/HomeCarouselViewListener.java
+++ b/app/src/main/java/org/gophillygo/app/HomeCarouselViewListener.java
@@ -1,9 +1,10 @@
 package org.gophillygo.app;
 
 import android.app.Activity;
-import androidx.databinding.DataBindingUtil;
 import android.view.LayoutInflater;
 import android.view.View;
+
+import androidx.databinding.DataBindingUtil;
 
 import com.synnapps.carouselview.ViewListener;
 

--- a/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
@@ -14,8 +14,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.synnapps.carouselview.CarouselView;
 
 import org.gophillygo.app.DetailCarouselViewListener;
@@ -29,8 +28,6 @@ import org.gophillygo.app.data.models.EventInfo;
 import org.gophillygo.app.tasks.AddRemoveGeofencesBroadcastReceiver;
 import org.gophillygo.app.tasks.RemoveGeofenceWorker;
 import org.gophillygo.app.utils.UserUtils;
-
-import io.fabric.sdk.android.Fabric;
 
 public abstract class AttractionDetailActivity extends AppCompatActivity {
 
@@ -71,15 +68,15 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Initialize Fabric/Crashlytics crash and usage data logging.
-        // Disable if user setting turned off; still must be initialized to avoid errors.
-        // Based on: https://stackoverflow.com/a/31996615
-        CrashlyticsCore core = new CrashlyticsCore.Builder().disabled(UserUtils.isFabricDisabled(this)).build();
-        Fabric.with(this, new Crashlytics.Builder().core(core).build());
+        // Initialize Firebase Crashlytics crash and usage data logging.
+        // Disable if user setting turned off
+        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        FirebaseCrashlytics crashlytics = FirebaseCrashlytics.getInstance();
+        crashlytics.setCrashlyticsCollectionEnabled(enableAnalytics);
 
         // Get or create unique, random UUID for app install for posting user flags
         userUuid = UserUtils.getUserUuid(getApplicationContext());
-        Crashlytics.setUserIdentifier(userUuid);
+        crashlytics.setUserId(userUuid);
         toggleClickListener = v -> {
             // click handler for toggling expanding/collapsing description card
             TextView descriptionView = findViewById(R.id.detail_description_text);
@@ -149,7 +146,7 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
         } else {
             String message = "Not opening website for attraction because it is missing a link";
             Log.e(LOG_LABEL, message);
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
         }
 
     }

--- a/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
@@ -4,15 +4,15 @@ import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.NotificationManagerCompat;
-import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.synnapps.carouselview.CarouselView;

--- a/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/AttractionDetailActivity.java
@@ -70,7 +70,7 @@ public abstract class AttractionDetailActivity extends AppCompatActivity {
 
         // Initialize Firebase Crashlytics crash and usage data logging.
         // Disable if user setting turned off
-        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        boolean enableAnalytics = UserUtils.isCrashlyticsEnabled(this);
         FirebaseCrashlytics crashlytics = FirebaseCrashlytics.getInstance();
         crashlytics.setCrashlyticsCollectionEnabled(enableAnalytics);
 

--- a/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
@@ -18,8 +18,7 @@ import androidx.appcompat.widget.SearchView;
 import androidx.cursoradapter.widget.CursorAdapter;
 import androidx.lifecycle.ViewModelProviders;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.data.DestinationViewModel;
 import org.gophillygo.app.data.models.AttractionInfo;
@@ -41,8 +40,6 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
-
-import io.fabric.sdk.android.Fabric;
 
 /**
  * Base activity that requests last known location and destination data when opened;
@@ -118,11 +115,10 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Initialize Fabric/Crashlytics crash and usage data logging.
-        // Disable if user setting turned off; still must be initialized to avoid errors.
-        // Based on: https://stackoverflow.com/a/31996615
-        CrashlyticsCore core = new CrashlyticsCore.Builder().disabled(UserUtils.isFabricDisabled(this)).build();
-        Fabric.with(this, new Crashlytics.Builder().core(core).build());
+        // Initialize Firebase Crashlytics crash and usage data logging.
+        // Disable if user setting turned off
+        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
 
         defaultLocation = new Location(DUMMY_LOCATION_PROVIDER);
         defaultLocation.setLatitude(DEFAULT_LATITUDE);
@@ -156,7 +152,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
 
             // Get or create unique, random UUID for app install for posting user flags
             userUuid = UserUtils.getUserUuid(this);
-            Crashlytics.setUserIdentifier(userUuid);
+            FirebaseCrashlytics.getInstance().setUserId(userUuid);
         });
     }
 

--- a/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
@@ -117,7 +117,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
 
         // Initialize Firebase Crashlytics crash and usage data logging.
         // Disable if user setting turned off
-        boolean enableAnalytics = !UserUtils.isFabricDisabled(this);
+        boolean enableAnalytics = UserUtils.isCrashlyticsEnabled(this);
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enableAnalytics);
 
         defaultLocation = new Location(DUMMY_LOCATION_PROVIDER);

--- a/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
@@ -16,7 +16,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.cursoradapter.widget.CursorAdapter;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
@@ -126,7 +126,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
 
         fetchLastLocationOrUseDefault();
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(DestinationViewModel.class);
         viewModel.getDestinations().observe(this, destinationResource -> {
             // shouldn't happen

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -18,7 +18,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.synnapps.carouselview.CarouselView;
 
 import org.gophillygo.app.BR;
@@ -99,7 +99,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
             if (eventInfo == null || eventInfo.getEvent() == null) {
                 String message = "No matching event found for ID " + eventId;
                 Log.e(LOG_LABEL, message);
-                Crashlytics.log(message);
+                FirebaseCrashlytics.getInstance().log(message);
                 return;
             }
 
@@ -114,7 +114,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
                         binding.setDestination(destinationInfo.getDestination());
                     } else {
                         String message = "No matching destination found for ID " + destinationId;
-                        Crashlytics.log(message);
+                        FirebaseCrashlytics.getInstance().log(message);
                         Log.e(LOG_LABEL, message);
                     }
                     // Since we call `getDestination(...).observe(...)` every time the event is updated,

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -38,6 +38,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -78,7 +79,7 @@ public class EventDetailActivity extends AttractionDetailActivity {
         // disable default app name title display
         toolbar.setTitle("");
         setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
         if (getIntent().hasExtra(EVENT_ID_KEY)) {
             eventId = getIntent().getLongExtra(EVENT_ID_KEY, -1);

--- a/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventDetailActivity.java
@@ -2,14 +2,6 @@ package org.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
-
-import androidx.appcompat.widget.PopupMenu;
-import androidx.appcompat.widget.Toolbar;
-import androidx.cardview.widget.CardView;
-import androidx.databinding.DataBindingUtil;
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProviders;
-
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.CalendarContract;
@@ -17,6 +9,13 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.Toast;
+
+import androidx.appcompat.widget.PopupMenu;
+import androidx.appcompat.widget.Toolbar;
+import androidx.cardview.widget.CardView;
+import androidx.databinding.DataBindingUtil;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.synnapps.carouselview.CarouselView;
@@ -92,8 +91,8 @@ public class EventDetailActivity extends AttractionDetailActivity {
 
         carouselView = findViewById(R.id.event_detail_carousel);
         carouselView.setIndicatorGravity(Gravity.CENTER_HORIZONTAL|Gravity.BOTTOM);
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
-        destinationViewModel = ViewModelProviders.of(this, viewModelFactory).get(DestinationViewModel.class);
+        viewModel = new ViewModelProvider(this, viewModelFactory).get(EventViewModel.class);
+        destinationViewModel = new ViewModelProvider(this, viewModelFactory).get(DestinationViewModel.class);
         viewModel.getEvent(eventId).observe(this, eventInfo -> {
             // TODO: #61 handle if event not found (go to list of events?)
             if (eventInfo == null || eventInfo.getEvent() == null) {

--- a/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -103,7 +103,7 @@ public class EventsListActivity extends FilterableListActivity
 
         // In addition to the destination data loaded by the BaseAttraction, get the full
         // events data here.
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(EventViewModel.class);
         LiveData<Resource<List<EventInfo>>> data = viewModel.getEvents();
         data.observe(this, destinationResource -> {

--- a/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsListActivity.java
@@ -1,6 +1,12 @@
 package org.gophillygo.app.activities;
 
 import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
@@ -8,13 +14,6 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.os.Bundle;
-import android.util.Log;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.View;
-import android.widget.TextView;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.adapters.EventsListAdapter;

--- a/app/src/main/java/org/gophillygo/app/activities/EventsMapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsMapsActivity.java
@@ -2,22 +2,23 @@ package org.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
-import androidx.databinding.DataBindingUtil;
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProvider;
-
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.databinding.DataBindingUtil;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModelProvider;
+
 import com.google.android.gms.maps.GoogleMap;
+
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.EventViewModel;
 import org.gophillygo.app.data.models.EventInfo;
 import org.gophillygo.app.data.networkresource.Resource;
 import org.gophillygo.app.data.networkresource.Status;
-import org.gophillygo.app.databinding.FilterButtonBarBinding;
 import org.gophillygo.app.databinding.ActivityEventsMapsBinding;
+import org.gophillygo.app.databinding.FilterButtonBarBinding;
 
 import java.util.HashMap;
 import java.util.List;

--- a/app/src/main/java/org/gophillygo/app/activities/EventsMapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/EventsMapsActivity.java
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import android.util.Log;
 import android.view.Menu;
@@ -38,7 +38,7 @@ public class EventsMapsActivity extends MapsActivity<EventInfo> {
     public void onMapReady(GoogleMap googleMap) {
         super.onMapReady(googleMap);
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory)
+        viewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(EventViewModel.class);
         LiveData<Resource<List<EventInfo>>> data = viewModel.getEvents();
         data.observe(this, eventsResource -> {

--- a/app/src/main/java/org/gophillygo/app/activities/FilterableListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/FilterableListActivity.java
@@ -2,10 +2,10 @@ package org.gophillygo.app.activities;
 
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.widget.Button;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
-import android.widget.Button;
 
 import org.gophillygo.app.BR;
 import org.gophillygo.app.FilterDialog;

--- a/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
@@ -8,14 +8,14 @@ import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
-import android.util.Log;
-import android.view.View;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -17,7 +17,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ScrollView;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.BR;
 import org.gophillygo.app.R;
@@ -91,7 +91,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
             if (destinationInfo == null || destinationInfo.getDestination() == null) {
                 String message = "No matching destination found for ID " + placeId;
                 Log.e(LOG_LABEL, message);
-                Crashlytics.log(message);
+                FirebaseCrashlytics.getInstance().log(message);
                 return;
             }
 
@@ -149,7 +149,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
         if (destinationInfo == null) {
             String message = "Cannot update flag because destination is not set";
             Log.e(LOG_LABEL, message);
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
             return;
         }
         String option = destinationInfo.getFlag().getOption().apiName;

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -2,6 +2,12 @@ package org.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ScrollView;
 
 import androidx.appcompat.widget.PopupMenu;
 import androidx.databinding.DataBindingUtil;
@@ -9,13 +15,6 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.os.Bundle;
-import android.util.Log;
-import android.view.Gravity;
-import android.view.MenuItem;
-import android.view.View;
-import android.widget.ScrollView;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -80,11 +80,11 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
         binding.placeDetailCarousel.setImageClickListener(position ->
                 Log.d(LOG_LABEL, "Clicked item: "+ position));
 
-        destinationViewModel = ViewModelProviders.of(this, viewModelFactory)
+        destinationViewModel = new ViewModelProvider(this, viewModelFactory)
                 .get(DestinationViewModel.class);
         LiveData<DestinationInfo> data = destinationViewModel.getDestination(placeId);
 
-        eventViewModel = ViewModelProviders.of(this, viewModelFactory).get(EventViewModel.class);
+        eventViewModel = new ViewModelProvider(this, viewModelFactory).get(EventViewModel.class);
 
         data.observe(this, destinationInfo -> {
             // TODO: #61 handle if destination not found (go to list of destinations?)

--- a/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlaceDetailActivity.java
@@ -65,7 +65,7 @@ public class PlaceDetailActivity extends AttractionDetailActivity implements Att
         // disable default app name title display
         binding.placeDetailToolbar.setTitle("");
         setSupportActionBar(binding.placeDetailToolbar);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
 
         if (getIntent().hasExtra(DESTINATION_ID_KEY)) {
             placeId = getIntent().getLongExtra(DESTINATION_ID_KEY, -1);

--- a/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
@@ -1,19 +1,18 @@
 package org.gophillygo.app.activities;
 
 import android.content.Intent;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.SearchView;
-import androidx.databinding.DataBindingUtil;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.SearchView;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.ListPreloader;

--- a/app/src/main/java/org/gophillygo/app/activities/PlacesMapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlacesMapsActivity.java
@@ -2,10 +2,11 @@ package org.gophillygo.app.activities;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
-import androidx.databinding.DataBindingUtil;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+
+import androidx.databinding.DataBindingUtil;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.models.DestinationInfo;

--- a/app/src/main/java/org/gophillygo/app/adapters/AttractionListAdapter.java
+++ b/app/src/main/java/org/gophillygo/app/adapters/AttractionListAdapter.java
@@ -2,22 +2,21 @@ package org.gophillygo.app.adapters;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.PopupMenu;
-import androidx.databinding.DataBindingUtil;
-import androidx.databinding.ViewDataBinding;
 import android.graphics.drawable.Drawable;
-import androidx.core.content.ContextCompat;
-import androidx.recyclerview.widget.DiffUtil;
-import androidx.recyclerview.widget.ListAdapter;
-import androidx.recyclerview.widget.RecyclerView;
-
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.core.content.ContextCompat;
+import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ViewDataBinding;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.ListAdapter;
+import androidx.recyclerview.widget.RecyclerView;
 
 import org.gophillygo.app.BR;
 import org.gophillygo.app.data.models.AttractionInfo;

--- a/app/src/main/java/org/gophillygo/app/adapters/PlaceCategoryGridAdapter.java
+++ b/app/src/main/java/org/gophillygo/app/adapters/PlaceCategoryGridAdapter.java
@@ -1,6 +1,9 @@
 package org.gophillygo.app.adapters;
 
 import android.content.Context;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
@@ -8,10 +11,6 @@ import androidx.databinding.ViewDataBinding;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.ViewGroup;
 
 import org.gophillygo.app.BR;
 import org.gophillygo.app.R;

--- a/app/src/main/java/org/gophillygo/app/adapters/PlaceCategoryGridAdapter.java
+++ b/app/src/main/java/org/gophillygo/app/adapters/PlaceCategoryGridAdapter.java
@@ -53,11 +53,7 @@ public class PlaceCategoryGridAdapter extends ListAdapter<CategoryAttraction, Pl
         super(new DiffUtil.ItemCallback<CategoryAttraction>() {
             @Override
             public boolean areItemsTheSame(@NonNull CategoryAttraction oldItem, @NonNull CategoryAttraction newItem) {
-                if (oldItem == null) {
-                    return newItem == null;
-                } else {
-                    return newItem != null && oldItem.getCategory().equals(newItem.getCategory());
-                }
+                return oldItem.getCategory().equals(newItem.getCategory());
             }
 
             @Override

--- a/app/src/main/java/org/gophillygo/app/data/models/AttractionFlag.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/AttractionFlag.java
@@ -12,6 +12,7 @@ import androidx.room.TypeConverter;
 import androidx.room.TypeConverters;
 
 import com.google.gson.annotations.SerializedName;
+
 import org.gophillygo.app.R;
 
 import java.util.Objects;

--- a/app/src/main/java/org/gophillygo/app/data/models/Filter.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/Filter.java
@@ -145,6 +145,7 @@ public class Filter extends BaseObservable implements Serializable {
         for (AttractionFlag.Option option : flags()) {
             if (flag.getOption() == option) {
                 flagMatches = true;
+                break;
             }
         }
         return flagMatches;

--- a/app/src/main/java/org/gophillygo/app/data/models/Filter.java
+++ b/app/src/main/java/org/gophillygo/app/data/models/Filter.java
@@ -1,8 +1,9 @@
 package org.gophillygo.app.data.models;
 
+import android.util.Log;
+
 import androidx.databinding.BaseObservable;
 import androidx.databinding.Bindable;
-import android.util.Log;
 
 import org.gophillygo.app.BR;
 

--- a/app/src/main/java/org/gophillygo/app/data/networkresource/LiveDataCallAdapter.java
+++ b/app/src/main/java/org/gophillygo/app/data/networkresource/LiveDataCallAdapter.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.reflect.Type;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,11 +32,13 @@ public class LiveDataCallAdapter<R> implements CallAdapter<R, LiveData<ApiRespon
         this.responseType = responseType;
     }
 
+    @NotNull
     @Override
     public Type responseType() {
         return responseType;
     }
 
+    @NotNull
     @Override
     public LiveData<ApiResponse<R>> adapt(@NonNull Call<R> call) {
         return new LiveData<ApiResponse<R>>() {

--- a/app/src/main/java/org/gophillygo/app/di/AppInjector.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppInjector.java
@@ -13,8 +13,8 @@ import androidx.fragment.app.FragmentManager;
 import org.gophillygo.app.GoPhillyGoApp;
 
 import dagger.android.AndroidInjection;
-import dagger.android.support.AndroidSupportInjection;
 import dagger.android.HasAndroidInjector;
+import dagger.android.support.AndroidSupportInjection;
 
 
 /**

--- a/app/src/main/java/org/gophillygo/app/di/AppInjector.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppInjector.java
@@ -14,7 +14,8 @@ import org.gophillygo.app.GoPhillyGoApp;
 
 import dagger.android.AndroidInjection;
 import dagger.android.support.AndroidSupportInjection;
-import dagger.android.support.HasSupportFragmentInjector;
+import dagger.android.HasAndroidInjector;
+
 
 /**
  * Based on:
@@ -65,7 +66,7 @@ public class AppInjector {
     }
 
     private static void handleActivity(Activity activity) {
-        if (activity instanceof HasSupportFragmentInjector) {
+        if (activity instanceof HasAndroidInjector) {
             AndroidInjection.inject(activity);
         }
         if (activity instanceof FragmentActivity) {

--- a/app/src/main/java/org/gophillygo/app/di/AppModule.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppModule.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import androidx.room.Room;
 
+import org.gophillygo.app.BuildConfig;
 import org.gophillygo.app.data.AttractionFlagDao;
 import org.gophillygo.app.data.DestinationDao;
 import org.gophillygo.app.data.DestinationWebservice;
@@ -39,14 +40,15 @@ class AppModule {
     DestinationWebservice provideDestinationWebservice() {
         // add network query logging by setting client on Retrofit
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
-        HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor();
 
         // Can be Level.BASIC, Level.HEADERS, or Level.BODY
         // See http://square.github.io/okhttp/3.x/logging-interceptor/ to see the options.
-        httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        builder.networkInterceptors().add(httpLoggingInterceptor);
+        if (BuildConfig.DEBUG) {
+            HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor();
+            httpLoggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            builder.networkInterceptors().add(httpLoggingInterceptor);
+        }
         OkHttpClient client = builder.build();
-
         return new Retrofit.Builder()
                 .client(client)
                 .baseUrl(DestinationWebservice.WEBSERVICE_URL)

--- a/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
+++ b/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
@@ -17,6 +17,8 @@ import org.gophillygo.app.tasks.AddGeofenceWorker;
 import org.gophillygo.app.tasks.AddRemoveGeofencesBroadcastReceiver;
 import org.gophillygo.app.utils.UserUtils;
 
+import java.util.Objects;
+
 public class GpgPreferenceFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     private static final String LOG_LABEL = "PreferenceFragment";
@@ -27,8 +29,8 @@ public class GpgPreferenceFragment extends PreferenceFragmentCompat implements S
 
         // reset user ID and show message when setting for that is clicked
         Preference reset = findPreference(getString(R.string.general_preferences_reset_uuid_key));
-        reset.setOnPreferenceClickListener(preference -> {
-            String uuid = UserUtils.resetUuid(getActivity());
+        Objects.requireNonNull(reset).setOnPreferenceClickListener(preference -> {
+            String uuid = UserUtils.resetUuid(Objects.requireNonNull(getActivity()));
             String message = getString(R.string.general_preferences_reset_uuid_message, uuid);
             Toast.makeText(getActivity(), message, Toast.LENGTH_LONG).show();
             return true;

--- a/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
+++ b/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
@@ -49,8 +49,8 @@ public class GpgPreferenceFragment extends PreferenceFragmentCompat implements S
         if (!isAdded() || getActivity() == null) {
             return;
         }
-        Log.d(LOG_LABEL, "shared preference changed");
 
+        Log.d(LOG_LABEL, "shared preference changed");
         final String notificationsKey = getString(R.string.general_preferences_allow_notifications_key);
         final String userFlagsKey = getString(R.string.general_preferences_send_flags_key);
         final String fabricKey = getString(R.string.general_preferences_fabric_logging_key);
@@ -68,9 +68,11 @@ public class GpgPreferenceFragment extends PreferenceFragmentCompat implements S
         } else if (key.equals(fabricKey)) {
             Log.d(LOG_LABEL, "toggled user setting for Fabric logging");
             // notify user to restart app for Fabric to stop logging, if setting changed to disable it
-            if (!sharedPreferences.getBoolean(fabricKey, false)) {
-                Toast.makeText(getActivity(), getString(R.string.general_preferences_fabric_logging_disabled_notification), Toast.LENGTH_LONG).show();
-            }
+            Toast.makeText(getActivity(), getString(R.string.general_preferences_fabric_logging_disabled_notification), Toast.LENGTH_LONG).show();
+            // Delete any unsent crash reports collected while logging was disabled,
+            // or else they will send on next app start.
+            Log.d(LOG_LABEL, "Delete any unsent crash reports (logging opt-in setting changed)");
+            FirebaseCrashlytics.getInstance().deleteUnsentReports();
         } else {
             String message = "Unrecognized user preference changed: " + key;
             Log.w(LOG_LABEL, message);

--- a/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
+++ b/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
@@ -30,7 +30,7 @@ public class GpgPreferenceFragment extends PreferenceFragmentCompat implements S
         // reset user ID and show message when setting for that is clicked
         Preference reset = findPreference(getString(R.string.general_preferences_reset_uuid_key));
         Objects.requireNonNull(reset).setOnPreferenceClickListener(preference -> {
-            String uuid = UserUtils.resetUuid(Objects.requireNonNull(getActivity()));
+            String uuid = UserUtils.resetUuid(requireActivity());
             String message = getString(R.string.general_preferences_reset_uuid_message, uuid);
             Toast.makeText(getActivity(), message, Toast.LENGTH_LONG).show();
             return true;

--- a/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
+++ b/app/src/main/java/org/gophillygo/app/fragments/GpgPreferenceFragment.java
@@ -5,23 +5,17 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.View;
-import android.widget.ListView;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.tasks.AddGeofenceWorker;
 import org.gophillygo.app.tasks.AddRemoveGeofencesBroadcastReceiver;
 import org.gophillygo.app.utils.UserUtils;
-
-import java.util.Objects;
 
 public class GpgPreferenceFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -78,7 +72,7 @@ public class GpgPreferenceFragment extends PreferenceFragmentCompat implements S
         } else {
             String message = "Unrecognized user preference changed: " + key;
             Log.w(LOG_LABEL, message);
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
         }
     }
 }

--- a/app/src/main/java/org/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -5,6 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.work.Data;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.GeofencingRequest;
@@ -15,11 +20,6 @@ import org.gophillygo.app.BuildConfig;
 
 import java.util.Map;
 import java.util.Objects;
-
-import androidx.annotation.NonNull;
-import androidx.work.Data;
-import androidx.work.Worker;
-import androidx.work.WorkerParameters;
 
 public class AddGeofenceWorker extends Worker {
 

--- a/app/src/main/java/org/gophillygo/app/tasks/AddGeofenceWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddGeofenceWorker.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.GeofencingRequest;
 import com.google.android.gms.location.LocationServices;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.BuildConfig;
 
@@ -87,7 +87,7 @@ public class AddGeofenceWorker extends Worker {
             geofenceNames = data.getStringArray(GEOFENCE_NAMES_KEY);
         } else {
             String message = "Data missing for geofences to add";
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
             Log.e(LOG_LABEL, message);
             return Result.failure();
         }
@@ -95,7 +95,7 @@ public class AddGeofenceWorker extends Worker {
         if (Objects.requireNonNull(latitudes).length != Objects.requireNonNull(longitudes).length || latitudes.length != Objects.requireNonNull(geofenceLabels).length ||
                 latitudes.length != Objects.requireNonNull(geofenceNames).length) {
             String message = "Location data for geofences to add should be arrays of the same length.";
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
             Log.e(LOG_LABEL, message);
             return Result.failure();
         }
@@ -111,7 +111,7 @@ public class AddGeofenceWorker extends Worker {
                     .setTransitionTypes(GEOFENCE_ENTER_TRIGGER | Geofence.GEOFENCE_TRANSITION_EXIT)
                     .build());
 
-            Crashlytics.log(ADD_GEOFENCE_EVENT);
+            FirebaseCrashlytics.getInstance().log(ADD_GEOFENCE_EVENT);
         }
 
         // Location access permissions prompting is handled by `GpgLocationUtils`.
@@ -127,16 +127,16 @@ public class AddGeofenceWorker extends Worker {
         } catch (SecurityException ex) {
             String message = "Missing permissions to add geofences";
             Log.e(LOG_LABEL, message);
-            Crashlytics.log(message);
-            Crashlytics.logException(ex);
+            FirebaseCrashlytics.getInstance().log(message);
+            FirebaseCrashlytics.getInstance().recordException(ex);
             ex.printStackTrace();
             return Result.failure();
         } catch (Exception ex) {
             String message = "Failed to add geofences";
             Log.e(LOG_LABEL, message);
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
             ex.printStackTrace();
-            Crashlytics.logException(ex);
+            FirebaseCrashlytics.getInstance().recordException(ex);
             return Result.failure();
         }
     }

--- a/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
@@ -8,8 +8,6 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
-
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.DestinationDao;
 import org.gophillygo.app.data.EventDao;
@@ -31,6 +29,9 @@ import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.WorkRequest;
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import dagger.android.AndroidInjection;
 
 import static org.gophillygo.app.tasks.RemoveGeofenceWorker.REMOVE_GEOFENCES_KEY;
@@ -100,7 +101,7 @@ public class AddRemoveGeofencesBroadcastReceiver extends BroadcastReceiver {
                     latitudes.length != Objects.requireNonNull(labels).length || latitudes.length != Objects.requireNonNull(names).length) {
                 String message = "Extras data of zero or mismatched length found";
                 Log.e(LOG_LABEL, message);
-                Crashlytics.log(message);
+                FirebaseCrashlytics.getInstance().log(message);
                 return;
             }
 
@@ -145,7 +146,7 @@ public class AddRemoveGeofencesBroadcastReceiver extends BroadcastReceiver {
                     if ((events == null || events.isEmpty()) &&
                             (destinations == null || destinations.isEmpty())) {
                         String message = "Have no destinations or events with geofences to add.";
-                        Crashlytics.log(message);
+                        FirebaseCrashlytics.getInstance().log(message);
                         Log.d(LOG_LABEL, message);
                         return null;
                     } else if (events == null) {
@@ -160,7 +161,7 @@ public class AddRemoveGeofencesBroadcastReceiver extends BroadcastReceiver {
                         // FIXME: handle having too many geofences
                         String message = "Too many destinations with geofences to add.";
                         Log.e(LOG_LABEL, message);
-                        Crashlytics.log(message);
+                        FirebaseCrashlytics.getInstance().log(message);
                         return null;
                     }
 

--- a/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
@@ -71,7 +71,7 @@ public class AddRemoveGeofencesBroadcastReceiver extends BroadcastReceiver {
 
         // Do not allow invoking broadcast receiver with unexpected action types
         if (!Intent.ACTION_BOOT_COMPLETED.equals(action) &&
-                !action.equals("org.gophillygo.app.tasks.ACTION_GEOFENCE_TRANSITION")) {
+                !Objects.equals(action, "org.gophillygo.app.tasks.ACTION_GEOFENCE_TRANSITION")) {
             Log.e(LOG_LABEL, "FIXME: Need to handle intent action type: " + intent.getAction());
             throw new UnsupportedOperationException("Unrecognized broadcast action type " + action);
         }

--- a/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/AddRemoveGeofencesBroadcastReceiver.java
@@ -8,6 +8,15 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+import androidx.work.Data;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.DestinationDao;
 import org.gophillygo.app.data.EventDao;
@@ -22,15 +31,6 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
-
-import androidx.annotation.NonNull;
-import androidx.preference.PreferenceManager;
-import androidx.work.Data;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
-
-import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import dagger.android.AndroidInjection;
 

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
@@ -7,6 +7,11 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import androidx.work.Data;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
@@ -21,10 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
-import androidx.work.Data;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
 import dagger.android.AndroidInjection;
 
 public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
@@ -7,9 +7,9 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.data.DestinationDao;
 import org.gophillygo.app.data.EventDao;
@@ -112,7 +112,7 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                                 if (destination == null) {
                                     String message = "Could not find destination for geofence " + geofenceId;
                                     Log.e(LOG_LABEL, message);
-                                    Crashlytics.log(message);
+                                    FirebaseCrashlytics.getInstance().log(message);
                                 } else {
                                     labels[i] = GeofenceTransitionWorker.DESTINATION_PREFIX + destination.getId();
                                     names[i] = destination.getName();

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionBroadcastReceiver.java
@@ -94,7 +94,7 @@ public class GeofenceTransitionBroadcastReceiver extends BroadcastReceiver {
                             Log.d(LOG_LABEL, "Handling transition for geofence " + fenceId);
                             // Geofence string ID is "d" for destination or "e" for event, followed by the
                             // destination or event integer ID.
-                            int geofenceId = Integer.valueOf(fenceId.substring(1));
+                            int geofenceId = Integer.parseInt(fenceId.substring(1));
                             boolean isEvent = fenceId.startsWith(GeofenceTransitionWorker.EVENT_PREFIX);
 
                             // query for each event or destination synchronously from the database

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -18,9 +18,9 @@ import androidx.core.app.TaskStackBuilder;
 import android.util.Log;
 
 import com.bumptech.glide.Glide;
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofenceStatusCodes;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.activities.EventDetailActivity;
@@ -113,7 +113,7 @@ public class GeofenceTransitionWorker extends Worker {
 
                 if (enteredGeofence) {
                     String message = "Entered geofence ID " + geofenceLabel + " for " + placeName;
-                    Crashlytics.log(message);
+                    FirebaseCrashlytics.getInstance().log(message);
                     Log.d(LOG_LABEL, message);
 
                     final Bitmap imageBitmap;
@@ -123,7 +123,7 @@ public class GeofenceTransitionWorker extends Worker {
                                 .submit(NOTIFICATION_IMAGE_WIDTH, NOTIFICATION_IMAGE_HEIGHT).get();
                     } catch (InterruptedException | ExecutionException e) {
                         e.printStackTrace();
-                        Crashlytics.logException(e);
+                        FirebaseCrashlytics.getInstance().recordException(e);
                     } finally {
                         imageBitmap = tmpBitmap; // initialize nullable final variable
                     }
@@ -178,7 +178,7 @@ public class GeofenceTransitionWorker extends Worker {
 
                 } else {
                     String message = "Exited geofence ID " + geofenceLabel;
-                    Crashlytics.log(message);
+                    FirebaseCrashlytics.getInstance().log(message);
                     Log.d(LOG_LABEL, message);
                     handler.post(() -> {
                         Log.d(LOG_LABEL, "Removing notification for geofence");
@@ -191,7 +191,7 @@ public class GeofenceTransitionWorker extends Worker {
             return Result.success();
         } else {
             String message = "Received a geofence transition event with no triggering geofences.";
-            Crashlytics.log(message);
+            FirebaseCrashlytics.getInstance().log(message);
             Log.w(LOG_LABEL, message);
             return Result.success();
         }
@@ -220,12 +220,12 @@ public class GeofenceTransitionWorker extends Worker {
                     notificationManager.createNotificationChannel(channel);
                 } else {
                     String message = "Have notification channel set up already";
-                    Crashlytics.log(message);
+                    FirebaseCrashlytics.getInstance().log(message);
                     Log.d(LOG_LABEL, message);
                 }
             } else {
                 String message = "Failed to get notification manager";
-                Crashlytics.log(message);
+                FirebaseCrashlytics.getInstance().log(message);
                 Log.e(LOG_LABEL, message);
             }
         }
@@ -280,7 +280,7 @@ public class GeofenceTransitionWorker extends Worker {
                 message = "Unrecognized GeofenceStatusCodes error value: " + error;
         }
         Log.e(LOG_LABEL, message);
-        Crashlytics.log(message);
+        FirebaseCrashlytics.getInstance().log(message);
         return result;
     }
 

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -10,12 +10,15 @@ import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.TaskStackBuilder;
-import android.util.Log;
+import androidx.work.Data;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
 
 import com.bumptech.glide.Glide;
 import com.google.android.gms.location.Geofence;
@@ -28,10 +31,6 @@ import org.gophillygo.app.activities.PlaceDetailActivity;
 
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-
-import androidx.work.Data;
-import androidx.work.Worker;
-import androidx.work.WorkerParameters;
 
 import static org.gophillygo.app.tasks.GeofenceTransitionBroadcastReceiver.GEOFENCE_IMAGES_KEY;
 

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -107,7 +107,7 @@ public class GeofenceTransitionWorker extends Worker {
 
                 // Geofence string ID is "d" for destination or "e" for event, followed by the
                 // destination or event integer ID.
-                int geofenceId = Integer.valueOf(geofenceLabel.substring(1));
+                int geofenceId = Integer.parseInt(geofenceLabel.substring(1));
                 boolean isEvent = geofenceLabel.startsWith(EVENT_PREFIX);
                 String notificationTag = isEvent ? EVENT_PREFIX : DESTINATION_PREFIX;
 

--- a/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/GeofenceTransitionWorker.java
@@ -188,13 +188,12 @@ public class GeofenceTransitionWorker extends Worker {
                 }
             }
 
-            return Result.success();
         } else {
             String message = "Received a geofence transition event with no triggering geofences.";
             FirebaseCrashlytics.getInstance().log(message);
             Log.w(LOG_LABEL, message);
-            return Result.success();
         }
+        return Result.success();
     }
 
     /**

--- a/app/src/main/java/org/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -3,6 +3,14 @@ package org.gophillygo.app.tasks;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.work.Data;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
@@ -13,14 +21,6 @@ import org.gophillygo.app.data.models.EventInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
-
-import androidx.annotation.NonNull;
-import androidx.work.Data;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
-import androidx.work.Worker;
-import androidx.work.WorkerParameters;
 
 public class RemoveGeofenceWorker extends Worker {
 

--- a/app/src/main/java/org/gophillygo/app/tasks/RemoveGeofenceWorker.java
+++ b/app/src/main/java/org/gophillygo/app/tasks/RemoveGeofenceWorker.java
@@ -3,9 +3,9 @@ package org.gophillygo.app.tasks;
 import android.content.Context;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.location.GeofencingClient;
 import com.google.android.gms.location.LocationServices;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.gophillygo.app.data.models.AttractionInfo;
 import org.gophillygo.app.data.models.EventInfo;
@@ -46,18 +46,18 @@ public class RemoveGeofenceWorker extends Worker {
             Log.d(LOG_LABEL, "Going to remove " + Objects.requireNonNull(removeGeofences).length + " geofences");
             geofencingClient.removeGeofences(new ArrayList<>(Arrays.asList(removeGeofences))).addOnSuccessListener(aVoid -> {
                 Log.d(LOG_LABEL, removeGeofences.length + " geofence(s) removed successfully");
-                Crashlytics.log(REMOVE_GEOFENCE_EVENT);
+                FirebaseCrashlytics.getInstance().log(REMOVE_GEOFENCE_EVENT);
             }).addOnFailureListener(e -> {
                 String errorMsg = "Failed to remove " + removeGeofences.length + " geofences.";
                 Log.d(LOG_LABEL, errorMsg);
-                Crashlytics.log(errorMsg);
-                Crashlytics.logException(e);
+                FirebaseCrashlytics.getInstance().log(errorMsg);
+                FirebaseCrashlytics.getInstance().recordException(e);
             });
             return Result.success();
         } else {
             String errorMsg = "Did not receive data for geofences to remove";
             Log.e(LOG_LABEL, errorMsg);
-            Crashlytics.log(errorMsg);
+            FirebaseCrashlytics.getInstance().log(errorMsg);
             return Result.failure();
         }
     }

--- a/app/src/main/java/org/gophillygo/app/utils/FlagMenuUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/FlagMenuUtils.java
@@ -3,6 +3,11 @@ package org.gophillygo.app.utils;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+import android.view.Gravity;
+import android.view.MenuItem;
+import android.view.View;
 
 import androidx.annotation.ColorRes;
 import androidx.appcompat.view.menu.MenuBuilder;
@@ -10,11 +15,6 @@ import androidx.appcompat.view.menu.MenuPopupHelper;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
-import android.text.SpannableString;
-import android.text.style.ForegroundColorSpan;
-import android.view.Gravity;
-import android.view.MenuItem;
-import android.view.View;
 
 import org.gophillygo.app.R;
 import org.gophillygo.app.data.models.AttractionFlag;

--- a/app/src/main/java/org/gophillygo/app/utils/GlideImageDataBinding.java
+++ b/app/src/main/java/org/gophillygo/app/utils/GlideImageDataBinding.java
@@ -1,8 +1,9 @@
 package org.gophillygo.app.utils;
 
 import android.content.Context;
-import androidx.databinding.BindingAdapter;
 import android.widget.ImageView;
+
+import androidx.databinding.BindingAdapter;
 
 import com.bumptech.glide.Glide;
 

--- a/app/src/main/java/org/gophillygo/app/utils/GpgLocationUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/GpgLocationUtils.java
@@ -11,10 +11,11 @@ import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Build;
 import android.provider.Settings;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;

--- a/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
@@ -126,7 +126,7 @@ public class UserUtils {
      * Check if user allows for posting anonymized crash and usage data to Fabric.
      *
      * @param context For getting strings and preferences
-     * @return False if Crashlytics may be enabled, True if it should be disabled
+     * @return True if Crashlytics should be enabled, False if it should be disabled
      */
     public static boolean isCrashlyticsEnabled(Context context) {
         String key = context.getString(R.string.general_preferences_fabric_logging_key);

--- a/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
@@ -126,7 +126,7 @@ public class UserUtils {
      * Check if user allows for posting anonymized crash and usage data to Fabric.
      *
      * @param context For getting strings and preferences
-     * @return False if Fabric may be enabled, True if it should be disabled
+     * @return False if Crashlytics may be enabled, True if it should be disabled
      */
     public static boolean isCrashlyticsEnabled(Context context) {
         String key = context.getString(R.string.general_preferences_fabric_logging_key);

--- a/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/UserUtils.java
@@ -128,9 +128,9 @@ public class UserUtils {
      * @param context For getting strings and preferences
      * @return False if Fabric may be enabled, True if it should be disabled
      */
-    public static boolean isFabricDisabled(Context context) {
+    public static boolean isCrashlyticsEnabled(Context context) {
         String key = context.getString(R.string.general_preferences_fabric_logging_key);
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-        return !sharedPreferences.contains(key) || !sharedPreferences.getBoolean(key, false);
+        return sharedPreferences.contains(key) && sharedPreferences.getBoolean(key, false);
     }
 }

--- a/app/src/main/res/layout/activity_events_maps.xml
+++ b/app/src/main/res/layout/activity_events_maps.xml
@@ -24,7 +24,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/events_map_toolbar" />
 
-            <fragment
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/events_map"
                 android:name="com.google.android.gms.maps.SupportMapFragment"
                 android:layout_below="@+id/events_map_filter_button_bar"

--- a/app/src/main/res/layout/activity_places_maps.xml
+++ b/app/src/main/res/layout/activity_places_maps.xml
@@ -24,7 +24,7 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/places_map_toolbar" />
 
-            <fragment
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/places_map"
                 android:name="com.google.android.gms.maps.SupportMapFragment"
                 android:layout_below="@+id/places_map_filter_button_bar"

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -23,7 +23,7 @@
                 tools:targetApi="lollipop" />
         </com.google.android.material.appbar.AppBarLayout>
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:name="org.gophillygo.app.fragments.GpgPreferenceFragment"
             app:layout_behavior="@string/appbar_scrolling_view_behavior"
             app:layout_constraintTop_toBottomOf="@id/preferences_app_bar"

--- a/build.gradle
+++ b/build.gradle
@@ -8,22 +8,16 @@ buildscript {
         }
         google()
         jcenter()
-        maven {
-            name 'fabric'
-            url 'https://maven.fabric.io/public'
-        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
-        // This belongs in the project-level build file, per
-        // https://firebase.google.com/docs/crashlytics/get-started
-        classpath 'io.fabric.tools:gradle:1.29.0'
-        classpath 'com.google.gms:google-services:4.0.1'
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.9.5'
+        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 03 15:39:54 EDT 2019
+#Wed Jun 10 15:06:32 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
## Overview

Switches the SDK for crash logging from Fabric's to Firebase's, since Fabric's SDK has been deprecated. Also updates the other dependencies and fixes some resulting syntax changes with dependency injection.

## Testing

- the Fabric properties file should no longer be needed
 - the app should continue to function as expected

I've tested on one device so far to confirm the app still works, but haven't yet tested:
 - [x] causing an exception to see that it shows up in Firebase
 - [x] sending a test log message to see that it shows up in Firebase
 - [x] whether the user setting to log or not is still respected
 - [x] other Android versions in emulators (only tested on the most recent)

I'll test the above before merging.


Closes #180 