### PR TITLE
Remove background location from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,16 +6,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
-    <!-- API 29+ -->
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <!--
     Allows Glide to monitor connectivity status and restart failed requests if users go from a
     a disconnected to a connected network state.
     -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <!-- Listen for reboot to set up geofences again -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- Disable Crashlytics reporting here so it can be enabled in code as an opt-in -->
     <meta-data


### PR DESCRIPTION
## Overview

Removes background location permission from the application manifest file.

### Demo

N/A

### Notes

#191 covered most of the geofencing removal; this was the last remaining bit.

## Testing Instructions

- Build and debug the app; everything should function correctly except that there should be no indication anywhere that the application may request background location updates.

Closes #188 
