### PR TITLE
Disable notifications toggle

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="general_preference_notifications">Notifications</string>
     <string name="general_preference_notifications_summary">Due to changes in Play Store policies, receiving notifications of nearby places is currently disabled.</string>
     <string name="general_preference_fabric_logging">Share crash and usage data</string>
-    <string name="general_preference_fabric_logging_summary">Send anonymous reports about how I\'m using the app and when the app crashes.</string>
+    <string name="general_preference_fabric_logging_summary">Send anonymous reports about app usage and crashes.</string>
     <string name="general_preferences_fabric_logging_disabled_notification">Please restart app for setting change to take effect.</string>
     <string name="general_preferences_send_flags">Share selections</string>
     <string name="general_preferences_send_flags_summary">Send us anonymous reports of which destinations and events you have marked as <i>been, liked, want to go,</i> or <i>not interested</i> so we can improve our listings.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,7 +125,7 @@
 
     <!-- settings -->
     <string name="general_preference_notifications">Notifications</string>
-    <string name="general_preference_notifications_summary">Notify me when I\'m near a place I like or want to go.</string>
+    <string name="general_preference_notifications_summary">Due to changes in Play Store policies, receiving notifications of nearby places is currently disabled.</string>
     <string name="general_preference_fabric_logging">Share crash and usage data</string>
     <string name="general_preference_fabric_logging_summary">Send anonymous reports about how I\'m using the app and when the app crashes.</string>
     <string name="general_preferences_fabric_logging_disabled_notification">Please restart app for setting change to take effect.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -36,9 +36,10 @@
         app:key="@string/general_preferences_key">
         <SwitchPreferenceCompat
             app:key="@string/general_preferences_allow_notifications_key"
-            app:defaultValue="true"
+            app:defaultValue="false"
             app:summary="@string/general_preference_notifications_summary"
-            app:title="@string/general_preference_notifications" />
+            app:title="@string/general_preference_notifications"
+            android:enabled="false" />
         <SwitchPreferenceCompat
             app:key="@string/general_preferences_fabric_logging_key"
             app:title="@string/general_preference_fabric_logging"


### PR DESCRIPTION
## Overview

Disables the preference toggle for notifications, and changes the help text to an explanation of why the toggle is disabled.

### Demo

![Screenshot_20210322-134625](https://user-images.githubusercontent.com/447977/112037050-b6a97680-8b17-11eb-84e7-1e192c6e68fc.png)

### Notes

@stephwall I think it might be good to run the copy by CAC before deploying; currently I feel like it reads a bit on the passive-aggressive side. I experimented with more neutral phrasing like "Notifications about nearby places are currently disabled" but I couldn't easily come up with a wording that couldn't be misinterpreted to mean "Notifications about nearby places are currently disabled [because something is wrong with the user's device and maybe they could be re-enabled if the user changes a setting]." I want to find a wording that's clear that the decision to disable the notifications was made by us and that the user can't do anything to re-enable it, but that they're not necessarily gone forever. Also CC @lederer in case you've got any thoughts (though unfortunately our time and budget constraints are pretty tight so I'm not sure how much maneuvering room we have with this).


## Testing Instructions

- Go to the app preferences screen
- Confirm that the Notifications preference appears disabled, that the control doesn't respond to taps, and that the help text matches the screenshot.

Closes #189 
