### PR TITLE
Upgrade app to target and compile level 31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,13 +31,13 @@ android {
     buildFeatures {
         dataBinding = true
     }
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "org.gophillygo.app"
         minSdkVersion 21
-        targetSdkVersion 30
-        versionCode 25
-        versionName "1.4.0"
+        targetSdkVersion 31
+        versionCode 26
+        versionName "1.4.1"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -104,7 +104,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-maps:17.0.0"
 
     // Android WorkManager
-    implementation 'android.arch.work:work-runtime:1.0.1'
+    implementation 'androidx.work:work-runtime:2.7.1'
 
     // Carousel
     implementation 'com.synnapps:carouselview:0.1.5'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="org.gophillygo.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!--


### PR DESCRIPTION
## Overview

This PR updates the target and compile level to 31.

### Notes

This PR does the absolute minimum on this. There are still quite a few linting warnings and other errors, which I've investigated and ultimately determined could be separated out into issue #209. Other than updating the target and compile SDK version numbers, version code, and version name, this PR also [updates the import for the AndroidWorkManager](https://developer.android.com/jetpack/androidx/releases/work), as this changed with the update to 31, and adds the option to share approximate, rather than precise, location, as [required by the update](https://developer.android.com/about/versions/12/behavior-changes-12#approximate-location).

## Testing Instructions

- Follow instructions from `README` to set up the project
- Set the build variant to "debug"  and add two new emulators to run SDK versions 21 and version 31
- Select one of your new emulators from the dropdown and click "debug" in the top righthand corner of Android Studio
- Allow the app to launch and then click around, paying attention to the logs in the "debug" window (found in the bottom lefthand corner of the screen)
- Make sure that everything works as expected and that the only errors are those described in issue #209 
 
Closes #201 
