### PR TITLE
Finish Android SDK 31 Upgrade

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -17,6 +17,7 @@
       </map>
     </option>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
@@ -269,31 +269,39 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
      * @param searchItem Item in the options menu for searching
      */
     protected void setupSearch(Menu menu, @IdRes int searchItem) {
-        // Get the SearchView and set the searchable configuration
-        SearchManager searchManager = (SearchManager)getSystemService(Context.SEARCH_SERVICE);
-        SearchView searchView = (SearchView) menu.findItem(searchItem).getActionView();
-        // Assumes current activity is the searchable activity
-        searchView.setSearchableInfo(Objects.requireNonNull(searchManager).getSearchableInfo(getComponentName()));
+        try {
+            // Get the SearchView and set the searchable configuration
+            SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
+            SearchView searchView = (SearchView) menu.findItem(searchItem).getActionView();
+            // Assumes current activity is the searchable activity
+            searchView.setSearchableInfo(Objects.requireNonNull(searchManager).getSearchableInfo(getComponentName()));
 
-        // handle opening detail intent from search
-        // https://developer.android.com/reference/android/widget/SearchView.OnSuggestionListener
-        searchView.setOnSuggestionListener(new SearchView.OnSuggestionListener() {
-            final CursorAdapter adapter = searchView.getSuggestionsAdapter();
+            // handle opening detail intent from search
+            // https://developer.android.com/reference/android/widget/SearchView.OnSuggestionListener
+            searchView.setOnSuggestionListener(new SearchView.OnSuggestionListener() {
+                final CursorAdapter adapter = searchView.getSuggestionsAdapter();
 
-            @Override
-            public boolean onSuggestionSelect(int position) {
-                Log.d(LOG_LABEL, "onSuggestionSelect " + position);
-                goToAttractionForPosition(adapter, position);
-                return true;
-            }
+                @Override
+                public boolean onSuggestionSelect(int position) {
+                    Log.d(LOG_LABEL, "onSuggestionSelect " + position);
+                    goToAttractionForPosition(adapter, position);
+                    return true;
+                }
 
-            @Override
-            public boolean onSuggestionClick(int position) {
-                Log.d(LOG_LABEL, "onSuggestionClick " + position);
-                goToAttractionForPosition(adapter, position);
-                return true;
-            }
-        });
+                @Override
+                public boolean onSuggestionClick(int position) {
+                    Log.d(LOG_LABEL, "onSuggestionClick " + position);
+                    goToAttractionForPosition(adapter, position);
+                    return true;
+                }
+            });
+        } catch (Exception ex) {
+            // Sometimes, the getSystemService() call will throw a
+            // ServiceManager.ServiceNotFoundException . It's not clear why this happens (most of
+            // the time it doesn't) or how we could reasonably recover, so if we ignore the error
+            // then the search will fail to initialize but the rest of the screen should continue to
+            // work.
+        }
     }
 
     protected void goToAttractionForPosition(CursorAdapter adapter, int position) {

--- a/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/BaseAttractionActivity.java
@@ -181,7 +181,8 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     /**
      * Override to listen to changes to data: either location or destinations source data.
      */
-    public void locationOrDestinationsChanged() { }
+    public void locationOrDestinationsChanged() {
+    }
 
     /**
      * Callback for {@link GpgLocationUtils.LocationUpdateListener}
@@ -249,10 +250,12 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == GpgLocationUtils.PERMISSION_REQUEST_ID) {
             if (grantResults.length > 0) {
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    Log.d(LOG_LABEL, "Re-requesting location after getting fine location permissions");
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED ||
+                        grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+                    Log.d(LOG_LABEL, "Re-requesting location after getting location permissions");
                     fetchLastLocationOrUseDefault();
-                } else if (grantResults[0] == PackageManager.PERMISSION_DENIED) {
+                } else if (grantResults[0] == PackageManager.PERMISSION_DENIED &&
+                        grantResults[1] == PackageManager.PERMISSION_DENIED) {
                     GpgLocationUtils.displayPermissionRequestRationale(getApplicationContext());
                 }
             }
@@ -262,7 +265,7 @@ public abstract class BaseAttractionActivity extends AppCompatActivity
     /**
      * Set up a search widget in the activity app bar.
      *
-     * @param menu Options menu
+     * @param menu       Options menu
      * @param searchItem Item in the options menu for searching
      */
     protected void setupSearch(Menu menu, @IdRes int searchItem) {

--- a/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/PlacesListActivity.java
@@ -77,7 +77,7 @@ public class PlacesListActivity extends FilterableListActivity implements
                 UserUtils.isFlagPostingEnabled(this));
 
         placesListAdapter.notifyItemChanged(position);
-	    return true;
+        return true;
     }
 
     @Override

--- a/app/src/main/java/org/gophillygo/app/utils/GpgLocationUtils.java
+++ b/app/src/main/java/org/gophillygo/app/utils/GpgLocationUtils.java
@@ -83,12 +83,15 @@ public class GpgLocationUtils {
         }
 
         String[] accessPermissions = new String[]{
-                Manifest.permission.ACCESS_FINE_LOCATION
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
         };
 
         // in API 23+, permission granting happens at runtime
         if (ActivityCompat.checkSelfPermission(callingActivity,
-                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
+                ActivityCompat.checkSelfPermission(callingActivity,
+                        Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
 
             // in case user has denied location permissions to app previously, tell them why it's needed, then prompt again
             if (ActivityCompat.shouldShowRequestPermissionRationale(callingActivity, Manifest.permission.ACCESS_FINE_LOCATION)) {
@@ -141,12 +144,11 @@ public class GpgLocationUtils {
     /**
      * Get the last known device location, without requesting to update it or prompting the user
      * for permissions if they haven't been granted.
-     *
+     * <p>
      * Intended for use by background tasks that do not have an Activity.
      *
-     * @param context Calling context
+     * @param context  Calling context
      * @param listener Callback for when location found. Must implement {@link LocationUpdateListener}
-     *
      * @return True if permissions have been already granted
      */
     public static boolean getLastKnownLocation(Context context, LocationUpdateListener listener) {
@@ -205,7 +207,7 @@ public class GpgLocationUtils {
                         client.getLastLocation().addOnCompleteListener(callingActivity, lastLocationTask -> {
                             if (lastLocationTask.isSuccessful() && lastLocationTask.getResult() != null) {
                                 Log.d(LOG_LABEL, "Got result " + lastLocationTask.getResult());
-                                ((LocationUpdateListener)callingActivity).locationFound(lastLocationTask.getResult());
+                                ((LocationUpdateListener) callingActivity).locationFound(lastLocationTask.getResult());
                             }
                         });
                     });

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
## Overview

We need to target at least Android SDK 31 in order to remain on the Play Store past August 31. The start of this work was completed in https://github.com/azavea/cac-tripplanner-android/pull/210 but there were still some outstanding issues that needed to be addressed. This addresses some of them, but not all (see notes, below).

### Demo

![Screenshot from 2023-07-26 12-06-03](https://github.com/azavea/cac-tripplanner-android/assets/447977/17f6426e-6a3b-47de-a9dc-828cde976204)


### Notes

There were a number of issues identified in #209 . Here's a list of the resolutions of each one:
> Some of the linting issues point to the deprecation of `AsyncTask`. Some quick Googling suggests there is no 1-to-1 replacement for this, so we should learn a bit more about fixing these would entail and if it's worth the effort to address this right now.

There are a lot of these spots and `AsyncTask` has just been deprecated, not removed, so we should punt until we're less time-crunched. I opened https://github.com/azavea/cac-tripplanner-android/issues/213 for this.

> We use features that are deprecated in Gradle v8, so we should decide whether those features are worth updating to upgrade our version of Gradle.

We should upgrade eventually but don't need to now because [Gradle's maintenance support extends back one major version](https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support). In other words, Gradle 7 will only receive support until Gradle 9 is released, but if we're on Gradle 8 then we'll have support until Gradle 10. I opened https://github.com/azavea/cac-tripplanner-android/issues/214 for this.

> We have been seeing `E/RecyclerView: No adapter attached; skipping layout` and ` E/PlacesList: image view not found; not setting up scroll listener` errors for the last couple of versions. Is there an easy fix for this or can it be fixed by a dependency upgrade?

I did some research on this and my best understanding is that this _seems_ like it could be from calling setAdapter() inside of an asynchronous callback: https://stackoverflow.com/questions/29141729/recyclerview-no-adapter-attached-skipping-layout . It mostly doesn't seem to hurt anything (although I think it might cause some images to be blank when they scroll into view), and we're going to have to rework the asynchronous code soon anyway, so I think it's best to punt on this for the time being. I opened https://github.com/azavea/cac-tripplanner-android/issues/215 to address this.

> `E/libprocessgroup: set_timerslack_ns write failed: Operation not permitted` errors appear on API level 28+ following issue #201. To replicate, go to the "places" map view, select an event from the map, or select filter on the map view. These errors appear to be related to the dialogue boxes and map.

I was able to replicate this, but the only discussion I was able to find online indicated that it happens when displaying a dialog over the map (which we do) and that the only solution is to avoid doing that, which would be more effort than we have time for. Luckily, it doesn't seem to harm anything so I think we can safely ignore this.

> Google's pre-launch report from releasing the app to testing resulted in the following error `java.lang.IllegalStateException: android.os.ServiceManager$ServiceNotFoundException: No service published for: search`. We should figure out how to replicate and address this issue.

I wasn't able to replicate this but it seems like there's only one spot in the code that could throw this exception, so I wrapped it in a try/catch and hopefully that'll do the trick.

> API level 31 added the ability to share approximate location instead of precise location. The app works if you only share approximate location, but you'll continue to see permissions pop ups and toast messages. We should try to find and fix whatever is checking again and again for precise location and update it to accept approximate location.

I changed the permission checking logic so that it works with either precise or approximate location.

One final note is that SDK is the minimum version to _remain_ on the Play Store, but in order to publish updates we need to target at least SDK 33. We should start on the SDK 33 upgrade as soon as SDK 31 is published.

## Testing Instructions

- Follow the setup instructions in the README until you've got the app working in an emulator, except don't try to set up a debug API key for the Google Maps API -- just use the release key in the password manager.
- Inside the emulator, set a GPS location that is within the Philly area but clearly different from City Hall.
- On the first time launching the app, grant it Precise Location permissions and confirm that the map appears in the correct spot (the app sometimes caches the location so if it shows up at City Hall you may need to use the location button to force a refresh, but then it should work correctly).
- Use the settings to remove all Location permissions from GoPhillyGo
- Launch the app again, but this time use Approximate location, and confirm that the app behaves essentially the same way (though it'll probably jump to City Hall again if the approximate location is too far from Philly).

Closes #209 
