### PR TITLE
Stop using AsyncTask

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="28629151">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
     buildFeatures {
         dataBinding = true
     }
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "org.gophillygo.app"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 32
         versionName "1.4.2"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
+++ b/app/src/main/java/org/gophillygo/app/activities/MapsActivity.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.View;
 
@@ -275,7 +276,7 @@ public abstract class MapsActivity<T extends AttractionInfo> extends FilterableL
 
         // Need to set map padding so "Google" logo is above popup, but we need to wait until the
         // popup is visible in order to measure it's height.
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
         handler.postDelayed(() -> googleMap.setPadding(0, 0, 0,
                 25 + popupBinding.mapPopupCard.getHeight()), 30);
     }

--- a/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
+++ b/app/src/main/java/org/gophillygo/app/data/networkresource/AttractionNetworkBoundResource.java
@@ -1,5 +1,7 @@
 package org.gophillygo.app.data.networkresource;
 
+import android.os.Handler;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
@@ -20,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -40,7 +43,8 @@ abstract public class AttractionNetworkBoundResource<A extends Attraction, I ext
 
     public AttractionNetworkBoundResource(DestinationWebservice webservice,
                                           DestinationDao destinationDao,
-                                          EventDao eventDao) {
+                                          EventDao eventDao, Executor executor, Handler handler) {
+        super(executor, handler);
         this.webservice = webservice;
         this.destinationDao = destinationDao;
         this.eventDao = eventDao;

--- a/app/src/main/java/org/gophillygo/app/di/AppModule.java
+++ b/app/src/main/java/org/gophillygo/app/di/AppModule.java
@@ -1,7 +1,10 @@
 package org.gophillygo.app.di;
 
 import android.app.Application;
+import android.os.Handler;
+import android.os.Looper;
 
+import androidx.core.os.HandlerCompat;
 import androidx.room.Room;
 
 import org.gophillygo.app.BuildConfig;
@@ -11,6 +14,10 @@ import org.gophillygo.app.data.DestinationWebservice;
 import org.gophillygo.app.data.EventDao;
 import org.gophillygo.app.data.GpgDatabase;
 import org.gophillygo.app.data.networkresource.LiveDataCallAdapterFactory;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.inject.Singleton;
 
@@ -83,4 +90,12 @@ class AppModule {
     AttractionFlagDao provideAttractionFlagDao(GpgDatabase db) {
         return db.attractionFlagDao();
     }
+
+    @Singleton
+    @Provides
+    ExecutorService provideBackgroundExecutor() { return Executors.newFixedThreadPool(1); }
+
+    @Singleton
+    @Provides
+    Handler provideMainThreadHandler() { return HandlerCompat.createAsync(Looper.getMainLooper());}
 }


### PR DESCRIPTION
## Overview

`AsyncTask` has been deprecated, so this stops using it.

### Demo

Here we are running on a Nexus 4 (2012) on Android SDK 22
![Screenshot from 2023-08-18 15-01-19](https://github.com/azavea/cac-tripplanner-android/assets/447977/bfb03874-e2ff-4555-9f6a-b991eeb9f630)

And on a Pixel 5 (2020) running Android SDK 33
![Screenshot from 2023-08-18 15-05-00](https://github.com/azavea/cac-tripplanner-android/assets/447977/f41df22d-8586-49bd-9770-f5b1c1539cf2)


### Notes

- I had read some indications that #215 might be being caused by trying to set up the views inside of an async function and thought we might be able to address it as part of this task. However, switching away from AsyncTask didn't solve the issue, and I didn't really see any indication that it impacted the PlacesListActivity at all. Since that part of this task went significantly quicker than estimated, I spent some extra time trying to see if I could separately diagnose and fix the RecyclerView errors, but I'm not a good enough Android debugger yet to easily track down what is going wrong. It still doesn't seem to cause any user-visible issues, so it didn't seem to be worth digging in too deeply and I left it as-is.
- I discovered that running automated tests seems to have broken at some point in the past, but it turns out we only have a single example test that runs anyway, so I don't think it's necessary to fix it unless we plan to add substantive testing at some point.
- Assigned @rachelekm because you should be at least partly spun up. There is no time pressure on this project any longer and I'll be out for a couple days right after you get back, so take your time!

## Testing Instructions

- As with the past several PRs, fire up the app and click around. Confirm that everything continues to work the same way that it always has.
 
Closes #213 