### PR TITLE
Include TODOs in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,11 @@ Optional. Screenshots, examples, etc.
 
 Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
 
+### Checklist
+
+- [ ] All TODOs have an accompanying link to an issue
+
+
 ## Testing Instructions
 
 - How to test this PR


### PR DESCRIPTION
## Overview

Adds TODOs to the PR template following team discussion.

## Testing Instructions

- There doesn't seem to be a good way to test this aside from merging it, unfortunately.
